### PR TITLE
feat: add LLM agent testing with Playwright MCP

### DIFF
--- a/.github/workflows/agent-tests.yml
+++ b/.github/workflows/agent-tests.yml
@@ -1,0 +1,104 @@
+# LLM Agent Tests — Smoke-test the Docker Compose environment
+# Builds the WordPress + SportsPress stack, verifies health, and collects artifacts.
+name: Agent Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  agent-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      # ── Checkout repositories ──────────────────────────────────────────
+      # Primary repo (sportspress-sandbox)
+      - name: Checkout sportspress-sandbox
+        uses: actions/checkout@v4
+
+      # Sibling repo required by compose volume mount
+      - name: Checkout SportsPress-Admin-Tools
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.repository_owner }}/SportsPress-Admin-Tools
+          path: ../SportsPress-Admin-Tools
+
+      # ── Build & start environment ──────────────────────────────────────
+      - name: Build and start Docker Compose environment
+        run: docker compose up -d --build --wait
+        timeout-minutes: 10
+
+      # ── Wait for health endpoint ───────────────────────────────────────
+      - name: Wait for health endpoint
+        run: |
+          echo "Waiting for health endpoint..."
+          for i in $(seq 1 60); do
+            if curl -sf http://localhost:8082/wp-json/test/v1/health; then
+              echo ""
+              echo "Health endpoint responded on attempt $i"
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "Health endpoint did not respond in time"
+          docker compose logs --tail=100
+          exit 1
+        timeout-minutes: 6
+
+      # ── Smoke tests ────────────────────────────────────────────────────
+      - name: Smoke test — health endpoint returns valid JSON
+        run: |
+          response=$(curl -sf http://localhost:8082/wp-json/test/v1/health)
+          echo "Health response: $response"
+          echo "$response" | python3 -c "import sys,json; json.load(sys.stdin)" \
+            || { echo "FAIL: health endpoint did not return valid JSON"; exit 1; }
+
+      - name: Smoke test — WordPress admin loads
+        run: |
+          status=$(curl -so /dev/null -w '%{http_code}' http://localhost:8082/wp-admin/)
+          echo "wp-admin status: $status"
+          if [ "$status" -lt 200 ] || [ "$status" -ge 400 ]; then
+            echo "FAIL: wp-admin returned HTTP $status"
+            exit 1
+          fi
+
+      # ── Collect artifacts from Docker volumes ──────────────────────────
+      - name: Collect screenshots and test results
+        if: always()
+        run: |
+          mkdir -p /tmp/artifacts/screenshots /tmp/artifacts/test-results
+          # Copy from named volumes via a helper container
+          docker run --rm \
+            -v sportspress-sandbox_screenshots:/src/screenshots:ro \
+            -v sportspress-sandbox_test-results:/src/test-results:ro \
+            -v /tmp/artifacts:/dst \
+            alpine sh -c "cp -r /src/screenshots/. /dst/screenshots/ 2>/dev/null; \
+                          cp -r /src/test-results/. /dst/test-results/ 2>/dev/null; \
+                          true"
+          echo "Collected artifacts:"
+          find /tmp/artifacts -type f || true
+
+      - name: Upload screenshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: screenshots
+          path: /tmp/artifacts/screenshots/
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: /tmp/artifacts/test-results/
+          if-no-files-found: ignore
+          retention-days: 14
+
+      # ── Tear down ─────────────────────────────────────────────────────
+      - name: Tear down environment
+        if: always()
+        run: docker compose down -v --remove-orphans

--- a/README.md
+++ b/README.md
@@ -1,41 +1,234 @@
 # SportsPress Docker Test Environment
 
-Complete WordPress + SportsPress test environment with automated sample data installation.
+Complete WordPress + SportsPress test environment with LLM agent automation support via Playwright MCP.
 
 ## Quick Start
 
 ```bash
-# Build and run
-docker build -f Dockerfile -t sportspress-test-env .
-docker run -p 8082:80 sportspress-test-env
+# Build and start all services (waits for healthy)
+docker compose up -d --build --wait
 
-# Or use docker-compose
-docker-compose up
+# Access points:
+# WordPress:      http://localhost:8082       (auto-login enabled)
+# Playwright MCP: http://localhost:3000/sse   (LLM agent endpoint)
+# REST Health:    http://localhost:8082/wp-json/test/v1/health
+# Mailhog:        http://localhost:8025
+# Adminer:        http://localhost:8080
 
-# Access at http://localhost:8082
-# Admin: admin/admin
-# Mailhog: http://localhost:8025
-# Adminer: http://localhost:8080
-
-## New Features
-- **Auto-Login**: You are automatically logged in as admin when visiting the site.
-- **Debug Tools**: Query Monitor, Debug Bar, and User Switching are pre-installed and active.
-- **MCP Server**: The WordPress MCP Server plugin is installed but inactive.
-- **Abilities API**: The WordPress Abilities API plugin is installed but inactive.
+# Stop everything
+docker compose down -v
 ```
+
+## Architecture
+
+```text
+┌─────────────────────────────────────────────────────┐
+│  LLM Agent (Kiro / Claude / GPT)                    │
+│  MCP: playwright @ localhost:3000/sse               │
+│  HTTP: REST API @ localhost:8082/wp-json/            │
+│  Shell: docker exec sportspress-test wp ...          │
+└──────────┬──────────────────┬───────────────────────┘
+           │ MCP (browser)    │ HTTP + docker exec
+           ▼                  ▼
+┌──────────────────┐   ┌─────────────────────────────┐
+│  playwright       │   │  sportspress-test            │
+│  Chromium +       │──▶│  Nginx + PHP-FPM + MariaDB   │
+│  MCP Server:3000  │   │  SportsPress + Admin Tools   │
+└──────────────────┘   │  WP-CLI + auto-login          │
+         └──── Docker Network (sp-test-net) ───────────┘
+```
+
+## Services
+
+| Service | Image | Port | Purpose |
+|---------|-------|------|---------|
+| sportspress-test | Custom (Alpine + WP) | 8082 | WordPress + SportsPress + MariaDB |
+| playwright | mcr.microsoft.com/playwright:v1.52.0-noble | 3000 | Browser automation MCP server |
+| mailhog | mailhog/mailhog | 8025 | Email capture |
+| adminer | adminer | 8080 | Database management |
+
+## LLM Agent Integration
+
+### Connecting an Agent
+
+Add the Playwright MCP server to your agent's MCP configuration:
+
+```json
+{
+  "mcpServers": {
+    "playwright": {
+      "url": "http://localhost:3000/sse"
+    }
+  }
+}
+```
+
+The agent can then use Playwright MCP tools to interact with WordPress:
+
+- `browser_navigate` — Navigate to URLs
+- `browser_click` — Click elements
+- `browser_type` — Type into form fields
+- `browser_screenshot` — Capture screenshots
+- `browser_snapshot` — Get accessibility tree (DOM structure)
+- `browser_evaluate` — Run JavaScript in the page
+
+### Internal URLs (from Playwright container)
+
+Inside the Docker network, WordPress is at `http://sportspress-test`. The agent should use this URL for browser navigation since Playwright runs inside the same Docker network.
+
+### Hybrid Testing Strategy
+
+The environment supports three testing channels:
+
+1. **Browser automation** (Playwright MCP) — UI interactions, form submissions, visual verification
+2. **REST API** — Data verification at `http://localhost:8082/wp-json/`
+3. **WP-CLI** — State management via `docker exec sportspress-test wp ... --allow-root`
+
+### Health Endpoint
+
+The REST API health endpoint verifies environment readiness:
+
+```bash
+curl http://localhost:8082/wp-json/test/v1/health
+```
+
+Returns:
+
+```json
+{
+  "status": "ready",
+  "wordpress": "6.9.4",
+  "sportspress": "2.7.29",
+  "sport": "ice-hockey",
+  "plugins": ["sportspress", "sportspress-admin-tools", ...],
+  "theme": "developer",
+  "timestamp": "2026-04-16T18:30:00+00:00"
+}
+```
+
+### Database State Reset
+
+A baseline database snapshot is created during container setup. Reset between test suites:
+
+```bash
+# From host
+./tests/reset-state.sh
+
+# Or manually
+docker exec sportspress-test wp db import /tmp/baseline.sql --allow-root
+docker exec sportspress-test wp cache flush --allow-root
+```
+
+## Test Suites
+
+Test suites are agent-readable markdown files in `tests/suites/`. Each file contains step-by-step instructions an LLM agent can follow using Playwright MCP.
+
+| Suite | File | Tests | Coverage |
+|-------|------|-------|----------|
+| Smoke Tests | 00-smoke.md | 7 | Environment readiness, auto-login, plugin activation |
+| Admin Tools Core | 01-admin-tools-core.md | 8 | Settings, tabs, modules, notifications, health dashboard |
+| Events Manager | 02-events-manager.md | 9 | Calendars, league tables, season rollover |
+| Schedule Generator | 03-schedule-generator.md | 27 | Config CRUD, generation, export, import, constraints |
+| Player Tools | 04-player-tools.md | 10 | Email meta, captain, stats, batch list creator |
+| League Manager | 05-league-manager.md | 14 | Dashboard, rosters, fees, health checker |
+| Player Registration | 06-player-registration.md | 10 | Settings, auto-create, duplicate detection |
+| e-Transfer Automation | 07-etransfer-automation.md | 15 | Webhooks, HMAC auth, manual match, logging |
+
+Total: ~100 test cases covering every feature of SportsPress Admin Tools.
+
+### Running Tests
+
+```bash
+# Run a single suite
+./tests/run-suite.sh tests/suites/00-smoke.md
+
+# Run all suites in order
+./tests/run-suite.sh all
+```
+
+### Test Result Format
+
+Agents produce JSON results that can be converted to JUnit XML:
+
+```bash
+# Convert JSON results to JUnit XML
+node tests/report-converter.js results.json report.xml
+
+# Or via stdin
+cat results.json | node tests/report-converter.js > report.xml
+```
+
+See `tests/README.md` for the full JSON schema and writing guide.
 
 ## Sports Available
 
 Set `SPORTSPRESS_SPORT` environment variable:
 
-- `soccer` (default in compose)
-- `basketball`, `baseball`, `ice-hockey`
-- `american-football`, `rugby-league`, `volleyball`
-- And more...
+- `soccer` (default), `basketball`, `baseball`, `ice-hockey`
+- `american-football`, `rugby-league`, `rugby-union`, `volleyball`
+- `australian-football`, `cricket`, `floorball`, `football`
+- `handball`, `netball`
+
+## Features
+
+- **Auto-Login** — Automatically logged in as admin (no credentials needed)
+- **Debug Tools** — Query Monitor, Debug Bar, and User Switching pre-installed
+- **MCP Server** — WordPress MCP Server plugin installed (inactive by default)
+- **Abilities API** — WordPress Abilities API plugin installed (inactive by default)
+- **DB Baseline** — Snapshot at `/tmp/baseline.sql` for state reset between tests
+- **REST Health** — `/wp-json/test/v1/health` for readiness checks
+
+## CI/CD
+
+The `agent-tests.yml` workflow runs on push to main and pull requests:
+
+1. Builds the Docker Compose environment
+2. Waits for the health endpoint
+3. Runs smoke tests (health API + wp-admin accessibility)
+4. Collects screenshots and test results as artifacts
+
+## Project Structure
+
+```text
+├── Dockerfile                          # WordPress + SportsPress container
+├── compose.yml                         # All services with Playwright MCP
+├── config/
+│   ├── scripts/
+│   │   ├── setup-test-data.sh          # WordPress + SportsPress setup + DB baseline
+│   │   ├── start.sh                    # Container entrypoint
+│   │   └── generate-extra-data.php     # Additional SportsPress data
+│   ├── wordpress/
+│   │   ├── wp-config.php               # WordPress configuration
+│   │   └── mu-plugins/
+│   │       ├── auto-login.php          # Auto-login for testing
+│   │       └── rest-api-health.php     # Health endpoint for agents
+│   ├── nginx/                          # Nginx configuration
+│   ├── php/                            # PHP-FPM + Xdebug configuration
+│   ├── mariadb/                        # MariaDB configuration
+│   └── supervisor/                     # Process management
+├── tests/
+│   ├── README.md                       # Test framework documentation
+│   ├── reset-state.sh                  # Database state reset
+│   ├── run-suite.sh                    # Test suite orchestrator
+│   ├── report-converter.js             # JSON → JUnit XML converter
+│   └── suites/                         # Agent-readable test plans
+│       ├── 00-smoke.md
+│       ├── 01-admin-tools-core.md
+│       ├── 02-events-manager.md
+│       ├── 03-schedule-generator.md
+│       ├── 04-player-tools.md
+│       ├── 05-league-manager.md
+│       ├── 06-player-registration.md
+│       └── 07-etransfer-automation.md
+└── .github/workflows/
+    ├── agent-tests.yml                 # LLM agent test pipeline
+    ├── build-image.yml                 # Docker image build
+    └── check-updates.yml               # Dependency update checks
+```
 
 ## External Database
 
-To use an external database instead of the bundled MariaDB, set the `WORDPRESS_DB_HOST` environment variable. The internal MariaDB service will be disabled.
+To use an external database instead of the bundled MariaDB:
 
 ```bash
 docker run -p 8082:80 \
@@ -45,10 +238,3 @@ docker run -p 8082:80 \
   -e WORDPRESS_DB_NAME=my-db \
   sportspress-test-env
 ```
-
-## Structure
-
-- `config/` - All configuration files organized by service
-- `.github/workflows/` - CI/CD automation
-- `Dockerfile` - Main container definition
-- `compose.yml` - Local development setup

--- a/compose.yml
+++ b/compose.yml
@@ -1,31 +1,94 @@
+# SportsPress Test Environment with LLM Agent Support
+# ===================================================
+# Provides WordPress + SportsPress + Playwright MCP for automated testing.
+#
+# Usage:
+#   docker compose up -d --wait    # Start all services, wait for healthy
+#   docker compose down             # Stop all services
+#
+# LLM Agent Connection:
+#   MCP Server:  http://localhost:3000/sse
+#   WordPress:   http://localhost:8082 (auto-login enabled)
+#   REST API:    http://localhost:8082/wp-json/test/v1/health
+#
+# The Playwright container connects to WordPress via the internal
+# Docker network at http://sportspress-test:80
+
 services:
+  # WordPress + SportsPress + MariaDB (all-in-one)
   sportspress-test:
     build:
       context: .
       dockerfile: Dockerfile
     ports:
-      - "8081:80"
+      - "8082:80"
       - "3306:3306"
     volumes:
-      - ../:/var/www/html/wp-content/plugins/sportspress-player-merge
+      # Mount the SportsPress Admin Tools plugin from sibling directory
+      - ../SportsPress-Admin-Tools:/var/www/html/wp-content/plugins/sportspress-admin-tools
+      # Persist screenshots and test results for review
+      - screenshots:/screenshots
+      - test-results:/test-results
     tmpfs:
-      - /dev/shm:size=100m
+      - /dev/shm:size=256m
     environment:
       - WORDPRESS_DB_HOST=localhost
       - WORDPRESS_DB_USER=wordpress
       - WORDPRESS_DB_PASSWORD=wordpress
       - WORDPRESS_DB_NAME=wordpress
       - SPORTSPRESS_SPORT=ice-hockey
-    links:
-      - mailhog
-      - adminer
+    networks:
+      - sp-test-net
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost/wp-json/test/v1/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 90s
 
+  # Playwright MCP Server — browser automation for LLM agents
+  # Exposes an MCP-compatible SSE endpoint that agents connect to.
+  # Chromium runs inside this container and navigates to WordPress
+  # over the shared Docker network.
+  playwright:
+    image: mcr.microsoft.com/playwright:v1.52.0-noble
+    depends_on:
+      sportspress-test:
+        condition: service_healthy
+    ports:
+      - "3000:3000"
+    volumes:
+      - screenshots:/screenshots
+      - test-results:/test-results
+    environment:
+      - DISPLAY=:99
+    command: >
+      npx @playwright/mcp@0.0.70
+      --port 3000
+      --host 0.0.0.0
+    networks:
+      - sp-test-net
+
+  # Mailhog — captures outgoing emails for verification
   mailhog:
     image: mailhog/mailhog
     ports:
       - "8025:8025"
+    networks:
+      - sp-test-net
 
+  # Adminer — lightweight database management UI
   adminer:
     image: adminer
     ports:
       - "8080:8080"
+    networks:
+      - sp-test-net
+
+networks:
+  sp-test-net:
+    driver: bridge
+
+volumes:
+  screenshots:
+  test-results:

--- a/config/scripts/setup-test-data.sh
+++ b/config/scripts/setup-test-data.sh
@@ -134,6 +134,12 @@ wp transient delete _sp_activation_redirect --allow-root 2>/dev/null || echo "No
 echo "✅ SportsPress $SPORT demo data installed!"
 echo "Demo includes: Teams, Players, Events, Statistics, and proper configurations"
 
+# Export database baseline for test state reset
+# Agents can restore this snapshot between test suites to ensure clean state.
+echo "Exporting database baseline snapshot..."
+wp db export /tmp/baseline.sql --allow-root
+echo "✅ Database baseline saved to /tmp/baseline.sql"
+
 # Keep the setup process running to prevent container exit
 echo "Setup completed, keeping process alive..."
 tail -f /dev/null

--- a/config/wordpress/mu-plugins/rest-api-health.php
+++ b/config/wordpress/mu-plugins/rest-api-health.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Plugin Name: REST API Health Endpoint
+ * Description: Provides a /wp-json/test/v1/health endpoint for container
+ *              healthchecks and LLM agent readiness verification.
+ *
+ * Returns JSON with WordPress version, SportsPress status, active plugins,
+ * and current sport configuration. Used by docker compose healthcheck and
+ * by agents before starting test suites.
+ */
+
+add_action('rest_api_init', function () {
+    // GET /wp-json/test/v1/health — public, no auth required
+    register_rest_route('test/v1', '/health', [
+        'methods'             => 'GET',
+        'callback'            => 'sp_test_health_callback',
+        'permission_callback' => '__return_true',
+    ]);
+});
+
+/**
+ * Health endpoint callback.
+ *
+ * @return WP_REST_Response Environment status for agent consumption.
+ */
+function sp_test_health_callback() {
+    // Gather active plugin slugs
+    $active_plugins = get_option('active_plugins', []);
+    $plugin_slugs   = array_map(function ($p) {
+        return dirname($p);
+    }, $active_plugins);
+
+    return new WP_REST_Response([
+        'status'       => 'ready',
+        'wordpress'    => get_bloginfo('version'),
+        'sportspress'  => defined('SP_VERSION') ? SP_VERSION : 'not-active',
+        'sport'        => get_option('sportspress_sport', 'unknown'),
+        'plugins'      => array_values($plugin_slugs),
+        'theme'        => get_stylesheet(),
+        'timestamp'    => gmdate('c'),
+    ], 200);
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,135 @@
+# SportsPress Test Framework
+
+LLM-agent-driven testing for the SportsPress WordPress plugin using Playwright MCP.
+
+## Overview
+
+An LLM agent connects to a Playwright MCP server, reads human-readable test suites (Markdown), executes them against a live WordPress instance, and produces structured JSON results. Helper scripts handle state reset, orchestration, and report conversion.
+
+## Directory Structure
+
+```
+tests/
+├── README.md              # This file
+├── reset-state.sh         # Reset DB to baseline between suites
+├── run-suite.sh           # Orchestrate suite execution
+├── report-converter.js    # Convert JSON results → JUnit XML
+├── suites/                # Test suite definitions (.md)
+│   ├── 00-smoke.md
+│   └── ...
+└── results/               # Timestamped output directories (git-ignored)
+    └── 20260416T144600/
+        ├── 00-smoke.md
+        └── 00-smoke.json
+```
+
+## Running Tests
+
+### Manual (single suite)
+
+```bash
+./tests/run-suite.sh tests/suites/00-smoke.md
+```
+
+### All suites
+
+```bash
+./tests/run-suite.sh all
+```
+
+The runner resets WordPress state before each suite, creates a timestamped results directory, and prints a summary.
+
+### State Reset Only
+
+```bash
+./tests/reset-state.sh
+```
+
+Works from the host (uses `docker exec`) or inside the container.
+
+## Writing New Test Suites
+
+1. Create a Markdown file in `tests/suites/` with a numeric prefix for ordering (e.g., `05-leagues.md`).
+2. Structure the file with a title, preconditions, and numbered test steps:
+
+```markdown
+# Suite: League Management
+
+## Preconditions
+- SportsPress plugin is active
+- At least one sport is configured
+
+## Tests
+
+### TEST-01: Create a league
+1. Navigate to SportsPress → Leagues
+2. Click "Add New"
+3. Enter name "Test League"
+4. Click "Add New League"
+5. **Expected:** League appears in the list
+```
+
+3. Each test should have a clear expected outcome the agent can verify.
+
+## Test Result Format
+
+The agent produces a JSON file per suite:
+
+```json
+{
+  "testSuite": "00-smoke",
+  "timestamp": "2026-04-16T14:46:00.000Z",
+  "tests": [
+    {
+      "id": "SMOKE-01",
+      "name": "WordPress loads",
+      "category": "smoke",
+      "status": "passed",
+      "duration_ms": 1200
+    },
+    {
+      "id": "SMOKE-02",
+      "name": "Admin login works",
+      "category": "smoke",
+      "status": "failed",
+      "duration_ms": 3400,
+      "error": "Login page returned 500",
+      "screenshot": "/screenshots/smoke-02-error.png"
+    }
+  ]
+}
+```
+
+### Field Reference
+
+| Field         | Type   | Required | Description                          |
+|---------------|--------|----------|--------------------------------------|
+| `testSuite`   | string | yes      | Suite identifier                     |
+| `timestamp`   | string | yes      | ISO-8601 execution timestamp         |
+| `tests`       | array  | yes      | Array of test result objects         |
+| `tests[].id`  | string | yes      | Unique test identifier               |
+| `tests[].name`| string | yes      | Human-readable test name             |
+| `tests[].category` | string | yes | Test category / grouping            |
+| `tests[].status` | string | yes   | `passed`, `failed`, or `skipped`     |
+| `tests[].duration_ms` | number | yes | Execution time in milliseconds    |
+| `tests[].error` | string | no     | Error message (when failed)          |
+| `tests[].screenshot` | string | no | Path to failure screenshot          |
+
+## Report Conversion
+
+Convert JSON results to JUnit XML for CI integration:
+
+```bash
+# stdin/stdout
+cat tests/results/*/00-smoke.json | node tests/report-converter.js
+
+# file arguments
+node tests/report-converter.js results/00-smoke.json report.xml
+```
+
+## Troubleshooting
+
+- **`baseline.sql not found`** — The container needs a baseline dump at `/tmp/baseline.sql`. Run `wp db export /tmp/baseline.sql --allow-root` inside the container after initial setup.
+- **State reset fails** — Ensure the `sportspress-test` container is running: `docker compose ps`.
+- **No results JSON** — The LLM agent writes results asynchronously. Check that the agent completed its run and wrote to the correct results directory.
+- **Permission denied on scripts** — Run `chmod +x tests/reset-state.sh tests/run-suite.sh`.

--- a/tests/report-converter.js
+++ b/tests/report-converter.js
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+// report-converter.js — Convert JSON test results to JUnit XML.
+//
+// Usage:
+//   cat results.json | node report-converter.js              # stdin → stdout
+//   node report-converter.js results.json                    # file  → stdout
+//   node report-converter.js results.json report.xml         # file  → file
+//
+// Expected JSON format:
+// {
+//   "testSuite": "string",
+//   "timestamp": "ISO-8601 string",
+//   "tests": [{
+//     "id": "string",
+//     "name": "string",
+//     "category": "string",
+//     "status": "passed" | "failed" | "skipped",
+//     "duration_ms": number,
+//     "error": "optional string",
+//     "screenshot": "optional string"
+//   }]
+// }
+
+const fs = require('fs');
+
+function escapeXml(s) {
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function convert(data) {
+  const suite = data.testSuite || 'unknown';
+  const timestamp = data.timestamp || new Date().toISOString();
+  const tests = Array.isArray(data.tests) ? data.tests : [];
+
+  const failures = tests.filter(t => t.status === 'failed').length;
+  const skipped = tests.filter(t => t.status === 'skipped').length;
+  const totalTime = tests.reduce((sum, t) => sum + (t.duration_ms || 0), 0) / 1000;
+
+  const lines = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    `<testsuites>`,
+    `  <testsuite name="${escapeXml(suite)}" tests="${tests.length}" failures="${failures}" skipped="${skipped}" time="${totalTime.toFixed(3)}" timestamp="${escapeXml(timestamp)}">`,
+  ];
+
+  for (const t of tests) {
+    const id = t.id || 'unknown';
+    const name = t.name || id;
+    const cls = t.category || suite;
+    const time = ((t.duration_ms || 0) / 1000).toFixed(3);
+
+    lines.push(`    <testcase name="${escapeXml(name)}" classname="${escapeXml(cls)}" time="${time}">`);
+
+    if (t.status === 'failed') {
+      const msg = t.error || 'Test failed';
+      lines.push(`      <failure message="${escapeXml(msg)}">${escapeXml(msg)}</failure>`);
+    } else if (t.status === 'skipped') {
+      lines.push('      <skipped/>');
+    }
+
+    if (t.screenshot) {
+      lines.push(`      <system-out>screenshot: ${escapeXml(t.screenshot)}</system-out>`);
+    }
+
+    lines.push('    </testcase>');
+  }
+
+  lines.push('  </testsuite>');
+  lines.push('</testsuites>');
+  return lines.join('\n') + '\n';
+}
+
+// Main
+(async () => {
+  let input;
+  const [inFile, outFile] = process.argv.slice(2);
+
+  if (inFile) {
+    input = fs.readFileSync(inFile, 'utf8');
+  } else {
+    input = fs.readFileSync('/dev/stdin', 'utf8');
+  }
+
+  if (!input.trim()) {
+    process.stderr.write('ERROR: Empty input\n');
+    process.exit(1);
+  }
+
+  let data;
+  try {
+    data = JSON.parse(input);
+  } catch (e) {
+    process.stderr.write(`ERROR: Invalid JSON — ${e.message}\n`);
+    process.exit(1);
+  }
+
+  const xml = convert(data);
+
+  if (outFile) {
+    fs.writeFileSync(outFile, xml);
+    process.stderr.write(`Wrote ${outFile}\n`);
+  } else {
+    process.stdout.write(xml);
+  }
+})();

--- a/tests/reset-state.sh
+++ b/tests/reset-state.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# reset-state.sh — Reset WordPress database to baseline state between test suites.
+# Works both from the host (via docker exec) and inside the container directly.
+set -euo pipefail
+
+CONTAINER="sportspress-test"
+BASELINE="/tmp/baseline.sql"
+
+# Run a WP-CLI command, routing through docker exec when on the host.
+wp_cmd() {
+  if [ -f /var/www/html/wp-config.php ]; then
+    wp --allow-root --path=/var/www/html "$@"
+  else
+    docker exec "$CONTAINER" wp --allow-root --path=/var/www/html "$@"
+  fi
+}
+
+# Verify baseline dump exists
+if [ -f /var/www/html/wp-config.php ]; then
+  [ -f "$BASELINE" ] || { echo "ERROR: $BASELINE not found inside container." >&2; exit 1; }
+else
+  docker exec "$CONTAINER" test -f "$BASELINE" || { echo "ERROR: $BASELINE not found in container $CONTAINER." >&2; exit 1; }
+fi
+
+echo "==> Importing baseline database..."
+if [ -f /var/www/html/wp-config.php ]; then
+  wp_cmd db import "$BASELINE"
+else
+  docker exec "$CONTAINER" wp --allow-root --path=/var/www/html db import "$BASELINE"
+fi
+
+echo "==> Flushing object cache..."
+wp_cmd cache flush
+
+echo "==> Flushing rewrite rules..."
+wp_cmd rewrite flush
+
+echo "==> State reset complete."

--- a/tests/run-suite.sh
+++ b/tests/run-suite.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# run-suite.sh — Orchestrate test suite execution.
+#
+# Usage:
+#   ./tests/run-suite.sh tests/suites/00-smoke.md   # run one suite
+#   ./tests/run-suite.sh all                         # run all suites in order
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SUITES_DIR="$SCRIPT_DIR/suites"
+RESET_SCRIPT="$SCRIPT_DIR/reset-state.sh"
+RESULTS_DIR="$SCRIPT_DIR/results/$(date +%Y%m%dT%H%M%S)"
+
+usage() {
+  echo "Usage: $0 <suite-file|all>"
+  echo "  suite-file  Path to a .md suite file (e.g., tests/suites/00-smoke.md)"
+  echo "  all         Run every suite in tests/suites/ in sorted order"
+  exit 1
+}
+
+[ $# -ge 1 ] || usage
+
+mkdir -p "$RESULTS_DIR"
+echo "Results directory: $RESULTS_DIR"
+
+# Build list of suites to run
+SUITES=()
+if [ "$1" = "all" ]; then
+  for f in "$SUITES_DIR"/*.md; do
+    [ -f "$f" ] || { echo "No suite files found in $SUITES_DIR" >&2; exit 1; }
+    SUITES+=("$f")
+  done
+else
+  [ -f "$1" ] || { echo "ERROR: Suite file not found: $1" >&2; exit 1; }
+  SUITES+=("$1")
+fi
+
+TOTAL=${#SUITES[@]}
+PASSED=0
+FAILED=0
+
+for suite in "${SUITES[@]}"; do
+  name="$(basename "$suite" .md)"
+  echo ""
+  echo "========================================"
+  echo "Suite: $name"
+  echo "========================================"
+
+  # Reset state before each suite
+  echo "--- Resetting state ---"
+  if ! "$RESET_SCRIPT"; then
+    echo "WARN: State reset failed for $name" >&2
+  fi
+
+  start=$(date +%s)
+
+  # Placeholder: the LLM agent runs the suite externally.
+  # Copy the suite file into results for reference.
+  cp "$suite" "$RESULTS_DIR/${name}.md"
+  echo "Suite file copied to $RESULTS_DIR/${name}.md"
+  echo "Awaiting test results in $RESULTS_DIR/${name}.json"
+
+  end=$(date +%s)
+  elapsed=$((end - start))
+
+  # Check for a results JSON (may be produced asynchronously by the agent)
+  result_file="$RESULTS_DIR/${name}.json"
+  if [ -f "$result_file" ]; then
+    if grep -q '"failed"' "$result_file"; then
+      echo "Status: FAILED (${elapsed}s)"
+      FAILED=$((FAILED + 1))
+    else
+      echo "Status: PASSED (${elapsed}s)"
+      PASSED=$((PASSED + 1))
+    fi
+  else
+    echo "Status: PENDING (${elapsed}s) — no results file yet"
+  fi
+done
+
+echo ""
+echo "========================================"
+echo "Summary: $TOTAL suite(s) | $PASSED passed | $FAILED failed | $((TOTAL - PASSED - FAILED)) pending"
+echo "Results: $RESULTS_DIR"
+echo "========================================"
+
+[ "$FAILED" -eq 0 ] || exit 1

--- a/tests/suites/00-smoke.md
+++ b/tests/suites/00-smoke.md
@@ -1,0 +1,124 @@
+# Test Suite: Smoke Tests
+
+## Prerequisites
+- Docker container `sportspress-test` is running
+- WordPress is installed and accessible at http://sportspress-test
+- Auto-login is enabled (no credentials needed)
+- SportsPress and all SPAT plugins are installed
+
+## Test Cases
+
+### TC-00-01: REST API Health Endpoint
+**Priority:** Critical
+**Type:** API
+
+**Steps:**
+1. Run: `docker exec sportspress-test wp eval "echo rest_url('test/v1/health');" --allow-root` to confirm the endpoint is registered.
+2. Use `browser_navigate` to go to `http://sportspress-test/wp-json/test/v1/health`.
+3. Use `browser_snapshot` to read the page content.
+
+**Expected Result:**
+- The endpoint returns a JSON response with a success/healthy status.
+- HTTP status code is 200.
+
+**Verification:**
+- `browser_snapshot` shows JSON with a health status field indicating success.
+
+### TC-00-02: WordPress Admin Dashboard Loads
+**Priority:** Critical
+**Type:** UI
+
+**Steps:**
+1. Use `browser_navigate` to go to `http://sportspress-test/wp-admin/`.
+2. Use `browser_snapshot` to capture the page structure.
+3. Confirm the page contains the WordPress dashboard heading (e.g., "Dashboard" or "Welcome to WordPress").
+
+**Expected Result:**
+- The admin dashboard loads without a login redirect.
+- The page title or heading contains "Dashboard".
+
+**Verification:**
+- `browser_snapshot` shows dashboard elements (admin menu, welcome panel, or "Dashboard" heading).
+- `browser_screenshot` for visual confirmation.
+
+### TC-00-03: SportsPress Menu Visible in Admin Sidebar
+**Priority:** Critical
+**Type:** UI
+
+**Steps:**
+1. Use `browser_navigate` to go to `http://sportspress-test/wp-admin/`.
+2. Use `browser_snapshot` to capture the page structure.
+3. Look for a sidebar menu item containing "SportsPress".
+
+**Expected Result:**
+- The admin sidebar contains a "SportsPress" top-level menu item.
+
+**Verification:**
+- `browser_snapshot` includes a menu element with text "SportsPress".
+
+### TC-00-04: SportsPress Admin Tools Settings Page Loads
+**Priority:** Critical
+**Type:** UI
+
+**Steps:**
+1. Use `browser_navigate` to go to `http://sportspress-test/wp-admin/options-general.php?page=sportspress-admin-tools`.
+2. Use `browser_snapshot` to capture the page structure.
+3. Confirm the page contains the SportsPress Admin Tools settings heading.
+
+**Expected Result:**
+- The settings page loads without errors.
+- The page contains "SportsPress Admin Tools" heading or settings form.
+
+**Verification:**
+- `browser_snapshot` shows settings page content with tabs or form fields.
+- No PHP errors or white screen.
+
+### TC-00-05: All Child Plugins Are Active
+**Priority:** Critical
+**Type:** API
+
+**Steps:**
+1. Run: `docker exec sportspress-test wp plugin list --status=active --format=table --allow-root`
+2. Check the output for these plugins:
+   - `sportspress` (core dependency)
+   - `sportspress-admin-tools` (parent plugin)
+   - `spat-events-manager` (child plugin)
+   - `spat-schedule-generator` (child plugin)
+
+**Expected Result:**
+- All listed plugins appear with status "active".
+
+**Verification:**
+- WP-CLI output shows each plugin as active.
+- Alternatively run: `docker exec sportspress-test wp plugin is-active sportspress --allow-root` (exit code 0 = active) for each plugin.
+
+### TC-00-06: Database Baseline Exists
+**Priority:** Critical
+**Type:** API
+
+**Steps:**
+1. Run: `docker exec sportspress-test ls -la /tmp/baseline.sql`
+2. Confirm the file exists and has a non-zero size.
+
+**Expected Result:**
+- `/tmp/baseline.sql` exists inside the container.
+- File size is greater than 0 bytes.
+
+**Verification:**
+- The `ls -la` command returns file details without "No such file or directory" error.
+
+### TC-00-07: Dashboard Screenshot for Visual Verification
+**Priority:** Medium
+**Type:** UI
+
+**Steps:**
+1. Use `browser_navigate` to go to `http://sportspress-test/wp-admin/`.
+2. Wait for the page to fully load.
+3. Use `browser_screenshot` to capture the full dashboard.
+
+**Expected Result:**
+- Screenshot shows a fully rendered WordPress admin dashboard.
+- No broken layout, missing styles, or PHP error notices.
+
+**Verification:**
+- Review the screenshot visually for correct layout and branding.

--- a/tests/suites/01-admin-tools-core.md
+++ b/tests/suites/01-admin-tools-core.md
@@ -1,0 +1,175 @@
+# Test Suite: Admin Tools Core
+
+## Prerequisites
+- Smoke tests (00-smoke.md) have passed.
+- SportsPress Admin Tools plugin is active.
+- Database is at baseline state. Restore if needed: `docker exec sportspress-test wp db import /tmp/baseline.sql --allow-root`
+
+## Test Cases
+
+### TC-01-01: Settings Page Loads
+**Priority:** Critical
+**Type:** UI
+
+**Steps:**
+1. Use `browser_navigate` to go to `http://sportspress-test/wp-admin/options-general.php?page=sportspress-admin-tools`.
+2. Use `browser_snapshot` to capture the page structure.
+3. Confirm the page contains the settings heading and form elements.
+
+**Expected Result:**
+- The page loads without errors.
+- A settings form is visible with tabs and input fields.
+
+**Verification:**
+- `browser_snapshot` shows the settings page with "SportsPress Admin Tools" heading.
+- `browser_screenshot` for visual confirmation.
+
+### TC-01-02: Tab Navigation Works
+**Priority:** Critical
+**Type:** UI
+
+**Steps:**
+1. Use `browser_navigate` to go to `http://sportspress-test/wp-admin/options-general.php?page=sportspress-admin-tools`.
+2. Use `browser_snapshot` to identify the tab elements.
+3. Click the "General" tab using `browser_click`. Use `browser_snapshot` to confirm it is active.
+4. Click the "Notifications" tab using `browser_click`. Use `browser_snapshot` to confirm it is active and shows notification-related fields.
+5. Click the "System Status" tab using `browser_click`. Use `browser_snapshot` to confirm it is active and shows system status content.
+
+**Expected Result:**
+- Each tab click switches the visible content area.
+- The active tab is visually highlighted.
+- Each tab shows its own set of fields/content.
+
+**Verification:**
+- `browser_snapshot` after each tab click shows the correct content for that tab.
+- `browser_screenshot` of each tab for visual confirmation.
+
+### TC-01-03: Module Enable/Disable Toggles Save
+**Priority:** Critical
+**Type:** UI
+
+**Steps:**
+1. Use `browser_navigate` to go to `http://sportspress-test/wp-admin/options-general.php?page=sportspress-admin-tools`.
+2. Use `browser_snapshot` to find module toggle checkboxes on the General tab.
+3. Note the current state of a module toggle (checked or unchecked).
+4. Click the toggle to change its state using `browser_click`.
+5. Click the "Save Changes" button using `browser_click`.
+6. Wait for the page to reload.
+7. Use `browser_snapshot` to confirm the toggle is in the new state.
+8. Toggle it back and save again to restore original state.
+
+**Expected Result:**
+- The toggle state changes when clicked.
+- After saving and page reload, the new state persists.
+
+**Verification:**
+- `browser_snapshot` after reload shows the updated toggle state.
+- Optionally verify via WP-CLI: `docker exec sportspress-test wp option get spat_settings --format=json --allow-root`
+
+### TC-01-04: Notification Settings Save
+**Priority:** High
+**Type:** UI
+
+**Steps:**
+1. Use `browser_navigate` to go to `http://sportspress-test/wp-admin/options-general.php?page=sportspress-admin-tools`.
+2. Click the "Notifications" tab using `browser_click`.
+3. Use `browser_snapshot` to identify notification fields (email address, toggle switches).
+4. Clear the email field and type a test email using `browser_type`: `test@example.com`.
+5. Toggle any notification enable/disable checkboxes using `browser_click`.
+6. Click "Save Changes" using `browser_click`.
+7. Wait for the page to reload.
+8. Click the "Notifications" tab again.
+9. Use `browser_snapshot` to confirm the email and toggle values persisted.
+
+**Expected Result:**
+- The email field shows `test@example.com` after reload.
+- Toggle states match what was set before saving.
+
+**Verification:**
+- `browser_snapshot` confirms saved values on the Notifications tab.
+- WP-CLI: `docker exec sportspress-test wp option get spat_settings --format=json --allow-root` shows notification settings.
+
+### TC-01-05: System Status Tab Shows Health Dashboard
+**Priority:** High
+**Type:** UI
+
+**Steps:**
+1. Use `browser_navigate` to go to `http://sportspress-test/wp-admin/options-general.php?page=sportspress-admin-tools`.
+2. Click the "System Status" tab using `browser_click`.
+3. Use `browser_snapshot` to capture the system status content.
+4. Verify the following sections are present:
+   - SportsPress status (version, active state)
+   - Plugin status (list of SPAT child plugins and their states)
+   - Cron health (scheduled tasks status)
+   - Database health (table status, size)
+
+**Expected Result:**
+- The System Status tab displays a health dashboard.
+- All four sections (SportsPress status, plugin status, cron health, database health) are visible.
+- Status indicators (icons, colors, or text) show current health.
+
+**Verification:**
+- `browser_snapshot` contains text related to each health section.
+- `browser_screenshot` for visual confirmation of the health dashboard layout.
+
+### TC-01-06: Copy Debug Info Button Works
+**Priority:** Medium
+**Type:** UI
+
+**Steps:**
+1. Use `browser_navigate` to go to `http://sportspress-test/wp-admin/options-general.php?page=sportspress-admin-tools`.
+2. Click the "System Status" tab using `browser_click`.
+3. Use `browser_snapshot` to locate the "Copy Debug Info" button.
+4. Click the "Copy Debug Info" button using `browser_click`.
+5. Use `browser_evaluate` to read the clipboard content: `navigator.clipboard.readText()`. If clipboard API is unavailable, check for a success notification or textarea with debug info.
+6. Use `browser_snapshot` to check for a success message or toast notification.
+
+**Expected Result:**
+- Clicking the button copies debug information to the clipboard or displays it in a textarea.
+- A success notification appears (e.g., "Copied!" or similar feedback).
+
+**Verification:**
+- `browser_snapshot` shows a success message after clicking.
+- If clipboard is accessible, the copied text contains system information.
+
+### TC-01-07: Settings Persist After Page Reload
+**Priority:** Critical
+**Type:** UI
+
+**Steps:**
+1. Use `browser_navigate` to go to `http://sportspress-test/wp-admin/options-general.php?page=sportspress-admin-tools`.
+2. Use `browser_snapshot` to note current settings values on the General tab.
+3. Change at least one setting value (e.g., toggle a checkbox or change a text field).
+4. Click "Save Changes" using `browser_click`.
+5. Wait for the page to reload.
+6. Use `browser_snapshot` to confirm the changed value persisted.
+7. Use `browser_navigate` to go to a different page: `http://sportspress-test/wp-admin/`.
+8. Use `browser_navigate` to return to `http://sportspress-test/wp-admin/options-general.php?page=sportspress-admin-tools`.
+9. Use `browser_snapshot` to confirm the setting still has the changed value.
+
+**Expected Result:**
+- Settings persist across page reloads and navigation away/back.
+
+**Verification:**
+- `browser_snapshot` on return visit shows the saved value.
+- WP-CLI: `docker exec sportspress-test wp option get spat_settings --format=json --allow-root`
+
+### TC-01-08: Unsaved Changes Warning
+**Priority:** High
+**Type:** UI
+
+**Steps:**
+1. Use `browser_navigate` to go to `http://sportspress-test/wp-admin/options-general.php?page=sportspress-admin-tools`.
+2. Use `browser_snapshot` to identify a form field.
+3. Change a setting value (e.g., toggle a checkbox or type in a text field) but do NOT save.
+4. Use `browser_evaluate` to check if a `beforeunload` event handler is registered: `window.onbeforeunload !== null` or check for a dirty form flag.
+5. Attempt to navigate away using `browser_click` on a sidebar menu link.
+6. Use `browser_snapshot` to check if a browser confirmation dialog or custom warning appeared.
+
+**Expected Result:**
+- Modifying a setting without saving marks the form as dirty.
+- Attempting to navigate away triggers a warning (browser `beforeunload` dialog or custom modal).
+
+**Verification:**
+- `browser_evaluate` confirms a `beforeunload` handler is set after form modification.
+- `browser_snapshot` or `browser_screenshot` shows the warning dialog if a custom one is used.

--- a/tests/suites/02-events-manager.md
+++ b/tests/suites/02-events-manager.md
@@ -1,0 +1,208 @@
+# Test Suite: Events Manager
+
+## Prerequisites
+- Smoke tests (00-smoke.md) have passed.
+- Admin Tools Core tests (01-admin-tools-core.md) have passed.
+- SportsPress Admin Tools and Events Manager child plugin are active.
+- SportsPress has at least one league and one season configured.
+- Database is at baseline state. Restore if needed: `docker exec sportspress-test wp db import /tmp/baseline.sql --allow-root`
+- Verify prerequisite data: `docker exec sportspress-test wp post list --post_type=sp_league --format=table --allow-root`
+- Verify seasons exist: `docker exec sportspress-test wp post list --post_type=sp_season --format=table --allow-root`
+
+## Test Cases
+
+### TC-02-01: Events Manager Tab Appears on Settings Page
+**Priority:** Critical
+**Type:** UI
+
+**Steps:**
+1. Use `browser_navigate` to go to `http://sportspress-test/wp-admin/options-general.php?page=sportspress-admin-tools`.
+2. Use `browser_snapshot` to capture the page structure.
+3. Look for an "Events Manager" tab in the tab navigation.
+
+**Expected Result:**
+- An "Events Manager" tab is visible alongside General, Notifications, and System Status tabs.
+
+**Verification:**
+- `browser_snapshot` shows a tab element with text "Events Manager".
+
+### TC-02-02: Calendar Management Settings Save
+**Priority:** Critical
+**Type:** UI
+
+**Steps:**
+1. Use `browser_navigate` to go to `http://sportspress-test/wp-admin/options-general.php?page=sportspress-admin-tools`.
+2. Click the "Events Manager" tab using `browser_click`.
+3. Use `browser_snapshot` to identify calendar management settings (auto-create toggle, naming convention field).
+4. Toggle the auto-create calendars setting using `browser_click`.
+5. If there is a naming convention field, clear it and type a new pattern using `browser_type` (e.g., `{league} - {season} Calendar`).
+6. Click "Save Changes" using `browser_click`.
+7. Wait for the page to reload.
+8. Click the "Events Manager" tab again.
+9. Use `browser_snapshot` to confirm the settings persisted.
+
+**Expected Result:**
+- Auto-create toggle state is saved.
+- Naming convention value persists after reload.
+
+**Verification:**
+- `browser_snapshot` confirms saved values on the Events Manager tab.
+- WP-CLI: `docker exec sportspress-test wp option get spat_settings --format=json --allow-root`
+
+### TC-02-03: Calendar Naming Preview Updates
+**Priority:** Medium
+**Type:** UI
+
+**Steps:**
+1. Use `browser_navigate` to go to `http://sportspress-test/wp-admin/options-general.php?page=sportspress-admin-tools`.
+2. Click the "Events Manager" tab using `browser_click`.
+3. Use `browser_snapshot` to locate the naming convention field and any preview element.
+4. Clear the naming convention field and type a new pattern using `browser_type` (e.g., `{league} {season} Games`).
+5. Use `browser_snapshot` to check if a preview element updated to show the resolved name.
+
+**Expected Result:**
+- A preview area shows what the calendar name will look like with actual league/season names substituted.
+- The preview updates dynamically as the naming pattern changes.
+
+**Verification:**
+- `browser_snapshot` shows a preview element with resolved placeholder values.
+
+### TC-02-04: Create Missing Calendars Button
+**Priority:** Critical
+**Type:** Hybrid
+
+**Steps:**
+1. Use `browser_navigate` to go to `http://sportspress-test/wp-admin/options-general.php?page=sportspress-admin-tools`.
+2. Click the "Events Manager" tab using `browser_click`.
+3. Use `browser_snapshot` to locate the "Create Missing Calendars" button.
+4. Count existing calendars before: `docker exec sportspress-test wp post list --post_type=sp_calendar --format=count --allow-root`
+5. Click the "Create Missing Calendars" button using `browser_click`.
+6. Wait for the AJAX operation to complete (watch for a spinner to disappear or success message).
+7. Use `browser_snapshot` to check for a success message.
+8. Count calendars after: `docker exec sportspress-test wp post list --post_type=sp_calendar --format=count --allow-root`
+
+**Expected Result:**
+- The button triggers calendar creation for any league/season combinations missing calendars.
+- A success message appears indicating how many calendars were created.
+
+**Verification:**
+- WP-CLI calendar count increased (or stayed the same if none were missing).
+- `browser_snapshot` shows success feedback.
+- List calendars: `docker exec sportspress-test wp post list --post_type=sp_calendar --format=table --allow-root`
+
+### TC-02-05: Reset Calendars Button
+**Priority:** High
+**Type:** Hybrid
+
+**Steps:**
+1. Use `browser_navigate` to go to `http://sportspress-test/wp-admin/options-general.php?page=sportspress-admin-tools`.
+2. Click the "Events Manager" tab using `browser_click`.
+3. Use `browser_snapshot` to locate the "Reset Calendars" button.
+4. Count existing calendars: `docker exec sportspress-test wp post list --post_type=sp_calendar --format=count --allow-root`
+5. Click the "Reset Calendars" button using `browser_click`.
+6. Use `browser_snapshot` to check if a confirmation dialog appears.
+7. If a confirmation dialog appears, confirm it by clicking the appropriate button.
+8. Wait for the operation to complete.
+9. Use `browser_snapshot` to check for a success message.
+10. Count calendars after: `docker exec sportspress-test wp post list --post_type=sp_calendar --format=count --allow-root`
+
+**Expected Result:**
+- A confirmation dialog appears before resetting (destructive action).
+- After confirmation, calendars are deleted and recreated.
+- A success message appears.
+
+**Verification:**
+- WP-CLI shows calendars were reset.
+- `browser_snapshot` shows success feedback.
+
+### TC-02-06: League Table Generator Modal
+**Priority:** Critical
+**Type:** UI
+
+**Steps:**
+1. Use `browser_navigate` to go to `http://sportspress-test/wp-admin/options-general.php?page=sportspress-admin-tools`.
+2. Click the "Events Manager" tab using `browser_click`.
+3. Use `browser_snapshot` to locate the League Table Generator section or button.
+4. Click the button to open the League Table Generator modal using `browser_click`.
+5. Use `browser_snapshot` to capture the modal content.
+6. Verify the modal contains:
+   - A league dropdown that is populated with existing leagues.
+   - A season dropdown that is populated with existing seasons.
+7. Select a league from the dropdown using `browser_click`.
+8. Select a season from the dropdown using `browser_click`.
+9. Click the "Create Table" or "Generate" button using `browser_click`.
+10. Wait for the operation to complete.
+11. Use `browser_snapshot` to check for a success message.
+
+**Expected Result:**
+- The modal opens with populated league and season dropdowns.
+- Selecting a league and season and clicking create generates a league table.
+- A success message confirms table creation.
+
+**Verification:**
+- `browser_snapshot` shows the modal with populated dropdowns.
+- After creation: `docker exec sportspress-test wp post list --post_type=sp_table --format=table --allow-root`
+- `browser_screenshot` of the modal for visual confirmation.
+
+### TC-02-07: Season Rollover Preview
+**Priority:** Critical
+**Type:** Hybrid
+
+**Steps:**
+1. Use `browser_navigate` to go to `http://sportspress-test/wp-admin/options-general.php?page=sportspress-admin-tools`.
+2. Click the "Events Manager" tab using `browser_click`.
+3. Use `browser_snapshot` to locate the Season Rollover section.
+4. Click the "Preview" or "Season Rollover" button using `browser_click`.
+5. Use `browser_snapshot` to capture the preview content.
+6. Verify the preview shows:
+   - Current season information.
+   - What changes will be made (new season name, affected leagues).
+
+**Expected Result:**
+- The preview displays a summary of changes that will occur during rollover.
+- Current and new season details are shown.
+
+**Verification:**
+- `browser_snapshot` shows preview content with season details.
+- `browser_screenshot` for visual confirmation.
+
+### TC-02-08: Season Rollover Execute
+**Priority:** Critical
+**Type:** Hybrid
+
+**Steps:**
+1. Continue from TC-02-07 or navigate to the Season Rollover section.
+2. Use `browser_snapshot` to locate the "Execute" or "Rollover" button.
+3. Count seasons before: `docker exec sportspress-test wp post list --post_type=sp_season --format=table --allow-root`
+4. Click the execute button using `browser_click`.
+5. If a confirmation dialog appears, confirm it.
+6. Wait for the operation to complete.
+7. Use `browser_snapshot` to check for a success message.
+8. Count seasons after: `docker exec sportspress-test wp post list --post_type=sp_season --format=table --allow-root`
+
+**Expected Result:**
+- A new season is created.
+- Success message confirms the rollover.
+
+**Verification:**
+- WP-CLI shows a new season post was created.
+- `docker exec sportspress-test wp post list --post_type=sp_season --format=table --allow-root` shows the new season.
+
+### TC-02-09: Verify Created Data via REST API and WP-CLI
+**Priority:** High
+**Type:** API
+
+**Steps:**
+1. Verify calendars exist: `docker exec sportspress-test wp post list --post_type=sp_calendar --fields=ID,post_title,post_status --format=table --allow-root`
+2. Verify league tables exist: `docker exec sportspress-test wp post list --post_type=sp_table --fields=ID,post_title,post_status --format=table --allow-root`
+3. Verify seasons exist: `docker exec sportspress-test wp post list --post_type=sp_season --fields=ID,post_title,post_status --format=table --allow-root`
+4. Use `browser_navigate` to go to `http://sportspress-test/wp-json/wp/v2/sp_calendar` to check REST API access.
+5. Use `browser_snapshot` to confirm JSON data is returned.
+
+**Expected Result:**
+- WP-CLI lists the created calendars, tables, and seasons.
+- REST API returns JSON data for calendars.
+
+**Verification:**
+- WP-CLI output shows posts with "publish" status.
+- REST API returns valid JSON arrays.

--- a/tests/suites/03-schedule-generator.md
+++ b/tests/suites/03-schedule-generator.md
@@ -1,0 +1,558 @@
+# Test Suite: Schedule Generator
+
+## Prerequisites
+- Smoke tests (00-smoke.md) have passed.
+- Admin Tools Core tests (01-admin-tools-core.md) have passed.
+- Events Manager tests (02-events-manager.md) have passed.
+- SportsPress Admin Tools and Schedule Generator child plugin are active.
+- SportsPress has leagues, seasons, and teams configured.
+- Database is at baseline state. Restore if needed: `docker exec sportspress-test wp db import /tmp/baseline.sql --allow-root`
+- Verify teams exist: `docker exec sportspress-test wp post list --post_type=sp_team --format=table --allow-root`
+- Verify leagues exist: `docker exec sportspress-test wp post list --post_type=sp_league --format=table --allow-root`
+- Verify venues exist: `docker exec sportspress-test wp post list --post_type=sp_venue --format=table --allow-root`
+
+## Test Cases
+
+### TC-03-01: Schedule Generator Page Loads
+**Priority:** Critical
+**Type:** UI
+
+**Steps:**
+1. Use `browser_navigate` to go to `http://sportspress-test/wp-admin/`.
+2. Use `browser_snapshot` to locate the "Schedule Generator" top-level menu item in the admin sidebar.
+3. Click the "Schedule Generator" menu item using `browser_click`.
+4. Use `browser_snapshot` to capture the page structure.
+
+**Expected Result:**
+- The Schedule Generator page loads from the top-level admin menu.
+- The page contains the main interface with tabs or sections for configuration, generation, and preview.
+
+**Verification:**
+- `browser_snapshot` shows the Schedule Generator interface.
+- `browser_screenshot` for visual confirmation.
+
+### TC-03-02: Import League Structure
+**Priority:** Critical
+**Type:** UI
+
+**Steps:**
+1. Navigate to the Schedule Generator page.
+2. Use `browser_snapshot` to locate the "Import League" button or dialog trigger.
+3. Click the "Import League" button using `browser_click`.
+4. Use `browser_snapshot` to capture the import dialog.
+5. Verify the dialog shows available leagues from SportsPress.
+6. Select a league to import using `browser_click`.
+7. Click the "Import" or "Confirm" button using `browser_click`.
+8. Wait for the import to complete.
+9. Use `browser_snapshot` to verify the league structure was imported (divisions, teams populated).
+
+**Expected Result:**
+- The import dialog opens and shows available SportsPress leagues.
+- After import, the configuration area shows the imported league structure with divisions and teams.
+
+**Verification:**
+- `browser_snapshot` shows imported league data in the configuration.
+- `browser_screenshot` of the imported structure.
+
+### TC-03-03: Create New Configuration
+**Priority:** Critical
+**Type:** UI
+
+**Steps:**
+1. Navigate to the Schedule Generator page.
+2. Use `browser_snapshot` to locate the configuration management area.
+3. Click "New Configuration" or similar button using `browser_click`.
+4. Use `browser_type` to enter a configuration name (e.g., `Test Config 2026`).
+5. Use `browser_snapshot` to confirm the new configuration form is active.
+
+**Expected Result:**
+- A new empty configuration is created with the given name.
+- The configuration form is ready for editing.
+
+**Verification:**
+- `browser_snapshot` shows the new configuration name and empty form fields.
+
+### TC-03-04: Add Divisions and Teams to Configuration
+**Priority:** Critical
+**Type:** UI
+
+**Steps:**
+1. Continue from TC-03-03 or create a new configuration.
+2. Use `browser_snapshot` to locate the "Add Division" button.
+3. Click "Add Division" using `browser_click`.
+4. Use `browser_type` to name the division (e.g., `Division A`).
+5. Use `browser_snapshot` to locate the "Add Team" button within the division.
+6. Click "Add Team" using `browser_click`.
+7. Select or type a team name. Repeat to add at least 4 teams.
+8. Use `browser_snapshot` to confirm divisions and teams are listed.
+
+**Expected Result:**
+- Divisions can be added to the configuration.
+- Teams can be added within each division.
+- The UI shows the hierarchical structure (division > teams).
+
+**Verification:**
+- `browser_snapshot` shows the division with teams listed.
+- `browser_screenshot` for visual confirmation.
+
+### TC-03-05: Set Date Range and Time Slots
+**Priority:** Critical
+**Type:** UI
+
+**Steps:**
+1. Continue from TC-03-04 or load an existing configuration.
+2. Use `browser_snapshot` to locate date range fields (start date, end date).
+3. Clear the start date field and use `browser_type` to enter `2026-09-01`.
+4. Clear the end date field and use `browser_type` to enter `2027-03-31`.
+5. Use `browser_snapshot` to locate time slot settings.
+6. Add a time slot (e.g., `19:00`) using the available UI controls.
+7. Use `browser_snapshot` to confirm date range and time slots are set.
+
+**Expected Result:**
+- Date range fields accept and display the entered dates.
+- Time slots can be added and are displayed in the configuration.
+
+**Verification:**
+- `browser_snapshot` shows the configured date range and time slots.
+
+### TC-03-06: Save Configuration
+**Priority:** Critical
+**Type:** UI
+
+**Steps:**
+1. Continue from TC-03-05 with a configured schedule.
+2. Use `browser_snapshot` to locate the "Save" button.
+3. Click "Save" using `browser_click`.
+4. Wait for the save operation to complete.
+5. Use `browser_snapshot` to check for a success message.
+
+**Expected Result:**
+- The configuration is saved successfully.
+- A success message or indicator appears.
+
+**Verification:**
+- `browser_snapshot` shows save confirmation.
+- Reload the page and verify the configuration persists.
+
+### TC-03-07: Load Configuration
+**Priority:** High
+**Type:** UI
+
+**Steps:**
+1. Navigate to the Schedule Generator page.
+2. Use `browser_snapshot` to locate the configuration selector or load button.
+3. Select the previously saved configuration (e.g., `Test Config 2026`) using `browser_click`.
+4. Use `browser_snapshot` to confirm the configuration loaded with all previously saved data (divisions, teams, dates, time slots).
+
+**Expected Result:**
+- The saved configuration loads with all its data intact.
+- Divisions, teams, date range, and time slots match what was saved.
+
+**Verification:**
+- `browser_snapshot` shows the loaded configuration data matching TC-03-03 through TC-03-05.
+
+### TC-03-08: Clone Configuration
+**Priority:** Medium
+**Type:** UI
+
+**Steps:**
+1. Load an existing configuration.
+2. Use `browser_snapshot` to locate the "Clone" button.
+3. Click "Clone" using `browser_click`.
+4. Use `browser_snapshot` to confirm a new configuration was created with copied data.
+5. Verify the cloned configuration has a different name (e.g., `Test Config 2026 (Copy)`).
+
+**Expected Result:**
+- A new configuration is created as a copy of the original.
+- All data (divisions, teams, dates, time slots) is duplicated.
+
+**Verification:**
+- `browser_snapshot` shows the cloned configuration with copied data and a new name.
+
+### TC-03-09: Delete Configuration
+**Priority:** High
+**Type:** UI
+
+**Steps:**
+1. Load the cloned configuration from TC-03-08.
+2. Use `browser_snapshot` to locate the "Delete" button.
+3. Click "Delete" using `browser_click`.
+4. Use `browser_snapshot` to check for a confirmation dialog.
+5. Confirm the deletion.
+6. Use `browser_snapshot` to verify the configuration is removed from the list.
+
+**Expected Result:**
+- A confirmation dialog appears before deletion.
+- After confirmation, the configuration is removed.
+
+**Verification:**
+- `browser_snapshot` shows the configuration is no longer in the list.
+
+### TC-03-10: Import Venues
+**Priority:** High
+**Type:** UI
+
+**Steps:**
+1. Navigate to the Schedule Generator page and load a configuration.
+2. Use `browser_snapshot` to locate the Venue Management section.
+3. Click "Import Venues" or similar button using `browser_click`.
+4. Use `browser_snapshot` to capture the import dialog.
+5. Verify existing SportsPress venues are listed.
+6. Select venues to import and confirm.
+7. Use `browser_snapshot` to verify venues appear in the configuration.
+
+**Expected Result:**
+- The import dialog shows available SportsPress venues.
+- Selected venues are added to the configuration.
+
+**Verification:**
+- `browser_snapshot` shows imported venues in the venue management area.
+
+### TC-03-11: Upload Venue CSV
+**Priority:** Medium
+**Type:** UI
+
+**Steps:**
+1. Navigate to the Venue Management section.
+2. Use `browser_snapshot` to locate the CSV upload area.
+3. Create a test CSV file via WP-CLI:
+   ```
+   docker exec sportspress-test bash -c 'echo "name,address,capacity\nTest Arena,123 Main St,5000\nTest Stadium,456 Oak Ave,10000" > /tmp/venues.csv'
+   ```
+4. Use the file upload control to upload the CSV (use `browser_evaluate` to set the file input if needed).
+5. Use `browser_snapshot` to verify the uploaded venues appear.
+
+**Expected Result:**
+- The CSV file is accepted and parsed.
+- Venues from the CSV appear in the venue list.
+
+**Verification:**
+- `browser_snapshot` shows the uploaded venues (Test Arena, Test Stadium).
+
+### TC-03-12: Add Blackout Dates
+**Priority:** High
+**Type:** UI
+
+**Steps:**
+1. Navigate to the Schedule Generator page and load a configuration.
+2. Use `browser_snapshot` to locate the Constraint System section or tab.
+3. Click to open the blackout dates area.
+4. Click "Add Blackout Date" using `browser_click`.
+5. Use `browser_type` to enter a date (e.g., `2026-12-25`).
+6. Optionally add a label (e.g., `Christmas`).
+7. Add another blackout date: `2027-01-01` with label `New Year`.
+8. Use `browser_snapshot` to confirm both blackout dates are listed.
+
+**Expected Result:**
+- Blackout dates can be added with dates and optional labels.
+- Added dates appear in the constraint list.
+
+**Verification:**
+- `browser_snapshot` shows both blackout dates in the list.
+
+### TC-03-13: Distribution Settings and Team Restrictions
+**Priority:** High
+**Type:** UI
+
+**Steps:**
+1. Continue in the Constraint System section.
+2. Use `browser_snapshot` to locate distribution settings (e.g., home/away balance, rest days between games).
+3. Adjust distribution settings using available controls.
+4. Use `browser_snapshot` to locate team restriction controls.
+5. Add a team restriction (e.g., a team cannot play on a specific day).
+6. Use `browser_snapshot` to confirm the restriction is listed.
+
+**Expected Result:**
+- Distribution settings can be adjusted.
+- Team-specific restrictions can be added and are displayed.
+
+**Verification:**
+- `browser_snapshot` shows updated distribution settings and team restrictions.
+
+### TC-03-14: Generate Schedule
+**Priority:** Critical
+**Type:** UI
+
+**Steps:**
+1. Ensure a complete configuration is loaded (divisions, teams, dates, time slots from previous tests).
+2. Save the configuration if not already saved.
+3. Use `browser_snapshot` to locate the "Generate Schedule" button.
+4. Click "Generate Schedule" using `browser_click`.
+5. Use `browser_snapshot` to monitor progress (look for a progress bar, percentage, or status messages).
+6. Wait for generation to complete (poll with `browser_snapshot` every few seconds).
+7. Use `browser_snapshot` to confirm generation completed successfully.
+
+**Expected Result:**
+- Generation starts and shows progress feedback.
+- Generation completes with a success message.
+- The generated schedule is available for preview.
+
+**Verification:**
+- `browser_snapshot` shows completion message.
+- `browser_screenshot` of the completed generation status.
+
+### TC-03-15: Cancel Generation
+**Priority:** Medium
+**Type:** UI
+
+**Steps:**
+1. Start a new schedule generation (click "Generate Schedule").
+2. Immediately use `browser_snapshot` to locate the "Cancel" button.
+3. Click "Cancel" using `browser_click`.
+4. Use `browser_snapshot` to confirm generation was cancelled.
+
+**Expected Result:**
+- The cancel button is available during generation.
+- Clicking cancel stops the generation process.
+- A cancellation message appears.
+
+**Verification:**
+- `browser_snapshot` shows cancellation confirmation.
+
+### TC-03-16: Preview Generated Schedule
+**Priority:** Critical
+**Type:** UI
+
+**Steps:**
+1. After a successful generation (TC-03-14), navigate to the preview section.
+2. Use `browser_snapshot` to capture the schedule preview.
+3. Verify the preview shows:
+   - Game dates and times.
+   - Home and away teams.
+   - Venues (if assigned).
+4. Test sorting: click a column header to sort using `browser_click`.
+5. Use `browser_snapshot` to confirm sorting changed the order.
+6. Test filtering: use any available filter controls (by date, team, division).
+7. Use `browser_snapshot` to confirm filtering reduced the displayed results.
+
+**Expected Result:**
+- The preview displays the generated schedule in a table format.
+- Sorting by columns works.
+- Filtering narrows the displayed games.
+
+**Verification:**
+- `browser_snapshot` shows schedule data with games, teams, dates.
+- `browser_screenshot` of the preview table.
+
+### TC-03-17: CSV Export
+**Priority:** High
+**Type:** UI
+
+**Steps:**
+1. After generation, navigate to the preview or export section.
+2. Use `browser_snapshot` to locate the "Export CSV" button.
+3. Click "Export CSV" using `browser_click`.
+4. Use `browser_evaluate` to check if a download was triggered or a blob URL was created.
+5. Alternatively, check for the downloaded file: `docker exec sportspress-test ls -la /tmp/*.csv --allow-root` (if server-side export).
+
+**Expected Result:**
+- Clicking export triggers a CSV file download.
+- The CSV contains the schedule data.
+
+**Verification:**
+- A file download is initiated (check via browser evaluation or server-side file).
+
+### TC-03-18: Import to SportsPress Preview
+**Priority:** Critical
+**Type:** UI
+
+**Steps:**
+1. After generation, use `browser_snapshot` to locate the "Import to SportsPress" button.
+2. Click the button using `browser_click`.
+3. Use `browser_snapshot` to capture the preview dialog.
+4. Verify the dialog shows:
+   - Number of events to be created.
+   - Summary of teams, dates, and venues.
+   - A confirm/cancel option.
+
+**Expected Result:**
+- A preview dialog opens showing what will be imported.
+- The dialog accurately summarizes the generated schedule.
+
+**Verification:**
+- `browser_snapshot` shows the import preview dialog with event count and summary.
+- `browser_screenshot` of the preview dialog.
+
+### TC-03-19: Import to SportsPress Execute
+**Priority:** Critical
+**Type:** Hybrid
+
+**Steps:**
+1. Continue from TC-03-18 with the import preview dialog open.
+2. Count existing events: `docker exec sportspress-test wp post list --post_type=sp_event --format=count --allow-root`
+3. Click the "Confirm Import" button using `browser_click`.
+4. Wait for the import to complete (monitor progress with `browser_snapshot`).
+5. Use `browser_snapshot` to check for a success message.
+6. Count events after: `docker exec sportspress-test wp post list --post_type=sp_event --format=count --allow-root`
+
+**Expected Result:**
+- The import creates SportsPress events for each game in the schedule.
+- A success message shows how many events were created.
+- Event count increases by the number of games in the schedule.
+
+**Verification:**
+- WP-CLI event count increased.
+- `docker exec sportspress-test wp post list --post_type=sp_event --fields=ID,post_title,post_date --format=table --allow-root` shows the new events.
+- `browser_snapshot` shows import success message.
+
+### TC-03-20: Placeholder Teams - Create
+**Priority:** High
+**Type:** UI
+
+**Steps:**
+1. Navigate to the Schedule Generator page.
+2. Use `browser_snapshot` to locate the Placeholder Teams section or button.
+3. Click to open the placeholder teams management area.
+4. Click "Create Placeholder" or similar button using `browser_click`.
+5. Use `browser_type` to enter a placeholder name (e.g., `TBD Team 1`).
+6. Create a second placeholder: `TBD Team 2`.
+7. Use `browser_snapshot` to confirm both placeholders are listed.
+
+**Expected Result:**
+- Placeholder teams can be created with custom names.
+- They appear in the team list and can be used in configurations.
+
+**Verification:**
+- `browser_snapshot` shows the placeholder teams.
+- WP-CLI: `docker exec sportspress-test wp post list --post_type=sp_team --format=table --allow-root` shows placeholder teams.
+
+### TC-03-21: Placeholder Teams - Replace with Real Teams
+**Priority:** High
+**Type:** UI
+
+**Steps:**
+1. Continue from TC-03-20 with placeholder teams created.
+2. Use `browser_snapshot` to locate the "Replace" button next to a placeholder team.
+3. Click "Replace" using `browser_click`.
+4. Use `browser_snapshot` to capture the replacement dialog.
+5. Select a real team from the dropdown or list.
+6. Confirm the replacement.
+7. Use `browser_snapshot` to verify the placeholder was replaced.
+
+**Expected Result:**
+- The replacement dialog shows available real teams.
+- After replacement, the placeholder is replaced with the real team in all scheduled events.
+
+**Verification:**
+- `browser_snapshot` shows the real team name where the placeholder was.
+- WP-CLI: verify events reference the real team ID.
+
+### TC-03-22: Change Tracking - View History
+**Priority:** Medium
+**Type:** UI
+
+**Steps:**
+1. Navigate to the Schedule Generator page.
+2. Use `browser_snapshot` to locate the Change Tracking section or history button.
+3. Click to open the change history.
+4. Use `browser_snapshot` to capture the history list.
+
+**Expected Result:**
+- The change history shows a log of actions performed (configurations saved, schedules generated, imports executed).
+- Each entry has a timestamp and description.
+
+**Verification:**
+- `browser_snapshot` shows history entries with timestamps.
+
+### TC-03-23: Change Tracking - Clear History
+**Priority:** Medium
+**Type:** UI
+
+**Steps:**
+1. Continue from TC-03-22 with the change history open.
+2. Use `browser_snapshot` to locate the "Clear History" button.
+3. Click "Clear History" using `browser_click`.
+4. Use `browser_snapshot` to check for a confirmation dialog.
+5. Confirm the clear action.
+6. Use `browser_snapshot` to verify the history is empty.
+
+**Expected Result:**
+- A confirmation dialog appears before clearing.
+- After confirmation, the history list is empty.
+
+**Verification:**
+- `browser_snapshot` shows an empty history or "No history" message.
+
+### TC-03-24: Unsaved Changes Warning
+**Priority:** High
+**Type:** UI
+
+**Steps:**
+1. Navigate to the Schedule Generator page and load a configuration.
+2. Make a change to the configuration (e.g., add a team, change a date).
+3. Do NOT save.
+4. Use `browser_evaluate` to check for a `beforeunload` handler: `typeof window.onbeforeunload === 'function'` or check for dirty state flags.
+5. Attempt to navigate away by clicking a sidebar menu link using `browser_click`.
+6. Use `browser_snapshot` to check for a warning dialog.
+
+**Expected Result:**
+- Modifying the configuration without saving sets a dirty flag.
+- Navigating away triggers a warning prompt.
+
+**Verification:**
+- `browser_evaluate` confirms `beforeunload` handler is active.
+- `browser_snapshot` or `browser_screenshot` shows the warning if a custom dialog is used.
+
+### TC-03-25: Settings Tab - Max Generation Time
+**Priority:** Medium
+**Type:** UI
+
+**Steps:**
+1. Navigate to the Schedule Generator page.
+2. Use `browser_snapshot` to locate the "Settings" tab.
+3. Click the "Settings" tab using `browser_click`.
+4. Use `browser_snapshot` to identify the max generation time field.
+5. Clear the field and use `browser_type` to enter `120` (seconds).
+6. Click "Save" using `browser_click`.
+7. Reload the page and navigate back to the Settings tab.
+8. Use `browser_snapshot` to confirm the value persisted.
+
+**Expected Result:**
+- The max generation time field accepts numeric input.
+- The value persists after save and reload.
+
+**Verification:**
+- `browser_snapshot` shows `120` in the max generation time field after reload.
+
+### TC-03-26: Settings Tab - Debug Logging and Timezone
+**Priority:** Medium
+**Type:** UI
+
+**Steps:**
+1. Navigate to the Schedule Generator Settings tab.
+2. Use `browser_snapshot` to identify the debug logging toggle and timezone selector.
+3. Toggle debug logging on using `browser_click`.
+4. Select a timezone (e.g., `America/New_York`) from the timezone dropdown.
+5. Click "Save" using `browser_click`.
+6. Reload the page and navigate back to the Settings tab.
+7. Use `browser_snapshot` to confirm both settings persisted.
+
+**Expected Result:**
+- Debug logging toggle state is saved.
+- Timezone selection is saved.
+- Both persist after reload.
+
+**Verification:**
+- `browser_snapshot` shows debug logging enabled and correct timezone selected.
+- WP-CLI: `docker exec sportspress-test wp option get spat_schedule_generator_settings --format=json --allow-root`
+
+### TC-03-27: Settings Tab - Change Tracking Toggle
+**Priority:** Medium
+**Type:** UI
+
+**Steps:**
+1. Navigate to the Schedule Generator Settings tab.
+2. Use `browser_snapshot` to locate the change tracking toggle.
+3. Note the current state.
+4. Toggle it to the opposite state using `browser_click`.
+5. Click "Save" using `browser_click`.
+6. Reload the page and navigate back to the Settings tab.
+7. Use `browser_snapshot` to confirm the toggle state changed.
+8. Toggle it back to the original state and save to restore defaults.
+
+**Expected Result:**
+- The change tracking toggle can be enabled/disabled.
+- The state persists after save and reload.
+
+**Verification:**
+- `browser_snapshot` confirms the toggled state after reload.

--- a/tests/suites/04-player-tools.md
+++ b/tests/suites/04-player-tools.md
@@ -1,0 +1,193 @@
+# Test Suite: Player Tools
+
+## Prerequisites
+- WordPress running at http://sportspress-test with auto-login enabled
+- SportsPress core plugin activated
+- SPAT Player Tools child plugin activated
+- WP-CLI available via `docker exec` or direct shell
+- At least one team and one player post exist (create via WP-CLI if needed)
+
+## Test Cases
+
+### TC-04-01: Player Tools Tab on SPAT Settings
+**Priority:** Critical
+**Type:** UI
+
+**Steps:**
+1. Navigate to http://sportspress-test/wp-admin/admin.php?page=spat-settings
+2. Look for a "Player Tools" tab or section on the settings page
+3. Click the Player Tools tab
+
+**Expected Result:**
+- The SPAT settings page loads without errors
+- A "Player Tools" tab is visible and clickable
+- Clicking the tab reveals Player Tools settings fields
+
+**Verification:**
+- Confirm the tab element exists in the DOM
+- Confirm no PHP errors or warnings appear on the page
+
+### TC-04-02: Player Modifications — Email Meta Box
+**Priority:** High
+**Type:** UI
+
+**Steps:**
+1. Create a player if none exist: `wp post create --post_type=sp_player --post_title="Test Player 04" --post_status=publish`
+2. Navigate to the player edit screen: http://sportspress-test/wp-admin/post.php?post={PLAYER_ID}&action=edit
+3. Look for an "Email" or "Player Email" meta box on the edit screen
+4. Enter a test email address `testplayer@example.com` in the email field
+5. Click "Update" to save the player
+
+**Expected Result:**
+- An email meta box appears on the player edit screen
+- The email value saves without error
+
+**Verification:**
+- Reload the player edit page and confirm the email value persists
+- Verify via WP-CLI: `wp post meta get {PLAYER_ID} sp_email` returns `testplayer@example.com`
+
+### TC-04-03: Player Modifications — Captain Selection
+**Priority:** High
+**Type:** UI
+
+**Steps:**
+1. Navigate to the player edit screen for the test player
+2. Look for a "Captain" checkbox or selection field
+3. Enable/check the captain option
+4. Click "Update" to save
+
+**Expected Result:**
+- A captain selection control is present on the player edit screen
+- The captain flag saves successfully
+
+**Verification:**
+- Reload the page and confirm the captain option remains checked
+- Verify via WP-CLI: `wp post meta get {PLAYER_ID} sp_captain` returns a truthy value
+
+### TC-04-04: Player Modifications — Squad Number
+**Priority:** High
+**Type:** UI
+
+**Steps:**
+1. Navigate to the player edit screen for the test player
+2. Look for a "Squad Number" or "Number" field
+3. Enter `10` as the squad number
+4. Click "Update" to save
+
+**Expected Result:**
+- A squad number field is present on the player edit screen
+- The value saves without error
+
+**Verification:**
+- Reload the page and confirm the squad number field shows `10`
+- Verify via WP-CLI: `wp post meta get {PLAYER_ID} sp_number` returns `10`
+
+### TC-04-05: Player Stats Enabler Toggle
+**Priority:** High
+**Type:** UI
+
+**Steps:**
+1. Navigate to http://sportspress-test/wp-admin/admin.php?page=spat-settings
+2. Click the Player Tools tab
+3. Locate the "Player Stats Enabler" or "Enable Frontend Stats" toggle
+4. Enable the toggle if it is off (or toggle it to the opposite state)
+5. Save settings
+
+**Expected Result:**
+- The toggle control is present and functional
+- Settings save without error
+- A success notice appears after saving
+
+**Verification:**
+- Reload the settings page and confirm the toggle state persisted
+- Navigate to a player's frontend page and check if stats are displayed (when enabled)
+
+### TC-04-06: Batch List Creator — Page Loads
+**Priority:** Critical
+**Type:** UI
+
+**Steps:**
+1. Navigate to http://sportspress-test/wp-admin/tools.php?page=upload-player-lists (or locate via Tools menu)
+2. If the exact URL differs, check the Tools menu for "Upload Player Lists" submenu item
+
+**Expected Result:**
+- The "Upload Player Lists" page loads without errors
+- The page contains a CSV upload form
+
+**Verification:**
+- Confirm the page title contains "Player Lists" or similar
+- Confirm a file upload input is present on the page
+
+### TC-04-07: Batch List Creator — CSV Upload
+**Priority:** Critical
+**Type:** Hybrid
+
+**Steps:**
+1. Create a test CSV file via WP-CLI: `echo "Team,Name\nTest Team,Player One\nTest Team,Player Two" > /tmp/test-players.csv`
+2. Navigate to the Upload Player Lists page
+3. Upload the CSV file using the file input
+4. Submit the upload form
+
+**Expected Result:**
+- The CSV is accepted and parsed
+- The page shows the parsed data with Team and Name columns recognized
+- No validation errors for the required columns
+
+**Verification:**
+- Confirm the upload response shows the correct number of rows (2 players)
+- Confirm Team and Name columns are identified
+
+### TC-04-08: Batch List Creator — AJAX Team/Player Search
+**Priority:** Medium
+**Type:** UI
+
+**Steps:**
+1. On the Upload Player Lists page, locate the team or player search field
+2. Type a partial team name (e.g., "Test") into the search field
+3. Wait for AJAX autocomplete results to appear
+
+**Expected Result:**
+- An AJAX request fires as the user types
+- Matching teams/players appear in a dropdown or suggestion list
+
+**Verification:**
+- Confirm the AJAX response returns results (check network tab or visible dropdown)
+- Confirm the search results include the expected team/player
+
+### TC-04-09: Batch List Creator — Player List Creation
+**Priority:** High
+**Type:** Hybrid
+
+**Steps:**
+1. After uploading the CSV in TC-04-07, proceed to create the player list
+2. Click the "Create" or "Import" button to finalize the player list
+3. Wait for the process to complete
+
+**Expected Result:**
+- Player list is created successfully
+- A success message is displayed
+- Players from the CSV are associated with the correct team
+
+**Verification:**
+- Verify via WP-CLI: `wp post list --post_type=sp_list --fields=ID,post_title` shows the new list
+- Verify via WP-CLI: `wp post list --post_type=sp_player --fields=ID,post_title` includes "Player One" and "Player Two"
+
+### TC-04-10: Settings Toggles Save Correctly
+**Priority:** Critical
+**Type:** UI
+
+**Steps:**
+1. Navigate to http://sportspress-test/wp-admin/admin.php?page=spat-settings
+2. Click the Player Tools tab
+3. Note the current state of all toggles/checkboxes
+4. Toggle each setting to the opposite state
+5. Save settings
+6. Reload the page
+
+**Expected Result:**
+- All toggled settings persist their new state after reload
+- No settings revert to their previous values
+
+**Verification:**
+- Compare each toggle state before and after reload — they must match
+- Verify via WP-CLI: `wp option get spat_player_tools_settings` (or equivalent option name) reflects the saved values

--- a/tests/suites/05-league-manager.md
+++ b/tests/suites/05-league-manager.md
@@ -1,0 +1,263 @@
+# Test Suite: League Manager
+
+## Prerequisites
+- WordPress running at http://sportspress-test with auto-login enabled
+- SportsPress core plugin activated
+- SPAT League Manager child plugin activated
+- WP-CLI available via `docker exec` or direct shell
+- At least one league, season, and team exist (create via WP-CLI if needed):
+  - `wp term create sp_league "Test League"`
+  - `wp term create sp_season "2026"`
+  - `wp post create --post_type=sp_team --post_title="Test Team LM" --post_status=publish`
+
+## Test Cases
+
+### TC-05-01: League Manager Menu Page Loads
+**Priority:** Critical
+**Type:** UI
+
+**Steps:**
+1. Navigate to http://sportspress-test/wp-admin/admin.php?page=league-manager
+2. If the exact URL differs, look for "League Manager" in the admin sidebar as a top-level menu item
+
+**Expected Result:**
+- A top-level "League Manager" menu item exists in the WordPress admin sidebar
+- The League Manager page loads without PHP errors or warnings
+
+**Verification:**
+- Confirm the menu item is visible in the sidebar
+- Confirm the page renders with a proper heading
+
+### TC-05-02: Dashboard Shows League Overview
+**Priority:** High
+**Type:** UI
+
+**Steps:**
+1. Navigate to the League Manager main page
+2. Review the dashboard content
+
+**Expected Result:**
+- The dashboard displays a league overview with summary information
+- Key metrics (teams count, players count, seasons, etc.) are visible
+
+**Verification:**
+- Confirm at least one summary widget or data section is present on the dashboard
+- Confirm the data reflects the current state (e.g., shows the test league/team)
+
+### TC-05-03: First-Run Wizard Appears and Can Be Dismissed
+**Priority:** High
+**Type:** UI
+
+**Steps:**
+1. Reset the wizard state via WP-CLI: `wp option delete spat_league_manager_wizard_complete` (or equivalent)
+2. Navigate to the League Manager page
+3. Observe if a first-run wizard or setup prompt appears
+4. Click "Dismiss", "Skip", or "Close" to dismiss the wizard
+
+**Expected Result:**
+- A first-run wizard or onboarding prompt appears on initial visit
+- The wizard can be dismissed via a button or link
+
+**Verification:**
+- After dismissing, reload the page and confirm the wizard does not reappear
+- Verify via WP-CLI: `wp option get spat_league_manager_wizard_complete` returns a truthy value
+
+### TC-05-04: Teams & Rosters — Filter by League/Season
+**Priority:** Critical
+**Type:** UI
+
+**Steps:**
+1. Navigate to the Teams & Rosters subpage under League Manager
+2. Locate the league filter dropdown and select "Test League"
+3. Locate the season filter dropdown and select "2026"
+4. Apply the filters
+
+**Expected Result:**
+- Filter dropdowns for league and season are present
+- Applying filters updates the team list to show only matching teams
+- The test team appears in the filtered results
+
+**Verification:**
+- Confirm the filtered results contain "Test Team LM"
+- Confirm teams from other leagues/seasons are excluded
+
+### TC-05-05: Teams & Rosters — View Roster
+**Priority:** High
+**Type:** UI
+
+**Steps:**
+1. On the Teams & Rosters page, click on "Test Team LM" or its "View Roster" link
+2. Review the roster display
+
+**Expected Result:**
+- The roster page loads showing players assigned to the team
+- Player names and relevant details are displayed
+
+**Verification:**
+- Confirm the roster page renders without errors
+- Confirm the team name is shown in the heading or breadcrumb
+
+### TC-05-06: Teams & Rosters — CSV Roster Upload Validation
+**Priority:** High
+**Type:** Hybrid
+
+**Steps:**
+1. Navigate to the Teams & Rosters page and locate the CSV upload feature
+2. Test with an invalid CSV (wrong columns): `echo "Foo,Bar\n1,2" > /tmp/bad-roster.csv`
+3. Upload the invalid CSV
+4. Test with an oversized file (if max upload size is configurable): create a file exceeding the limit
+5. Test with a non-CSV MIME type: rename a text file to `.pdf` and attempt upload
+
+**Expected Result:**
+- Invalid column CSV is rejected with a clear error message about required columns
+- Oversized files are rejected with a file size error
+- Non-CSV MIME types are rejected with a MIME type error
+
+**Verification:**
+- Confirm each invalid upload produces an appropriate error message
+- Confirm no data is imported from invalid files
+
+### TC-05-07: Teams & Rosters — Valid CSV Roster Upload
+**Priority:** Critical
+**Type:** Hybrid
+
+**Steps:**
+1. Create a valid roster CSV: `echo "Name,Number,Position\nJohn Doe,7,Forward\nJane Smith,10,Midfielder" > /tmp/valid-roster.csv`
+2. Navigate to the Teams & Rosters page
+3. Select "Test Team LM" as the target team
+4. Upload the valid CSV
+5. Submit the import
+
+**Expected Result:**
+- The CSV is accepted and parsed successfully
+- Players are imported and associated with the team
+- A success message shows the number of players imported
+
+**Verification:**
+- Verify via WP-CLI: `wp post list --post_type=sp_player --fields=ID,post_title` includes "John Doe" and "Jane Smith"
+
+### TC-05-08: Fee Status Subpage
+**Priority:** High
+**Type:** UI
+
+**Steps:**
+1. Navigate to the Fee Status subpage under League Manager
+2. Search for or select a player to check fee status
+3. Review the fee status display
+
+**Expected Result:**
+- The Fee Status page loads without errors
+- A player lookup/search mechanism is available
+- Fee status information is displayed for the selected player
+
+**Verification:**
+- Confirm the page contains a search or filter control
+- Confirm fee status data renders (paid/unpaid/pending or similar)
+
+### TC-05-09: Health Checker — Run Check via AJAX
+**Priority:** Medium
+**Type:** Hybrid
+
+**Steps:**
+1. Navigate to the League Manager page or a subpage with the Health Checker
+2. Locate the "Run Health Check" or similar button
+3. Click the button and wait for the AJAX request to complete
+
+**Expected Result:**
+- An AJAX request is sent when the button is clicked
+- A loading indicator appears during the check
+- Results are displayed after the check completes
+
+**Verification:**
+- Confirm the AJAX response returns a 200 status
+- Confirm the results section populates with health check data
+
+### TC-05-10: Health Checker — View Results
+**Priority:** Medium
+**Type:** UI
+
+**Steps:**
+1. After running the health check in TC-05-09, review the results
+2. Check for any warnings or issues flagged
+
+**Expected Result:**
+- Results are displayed in a readable format (table, list, or cards)
+- Each check item shows a pass/fail/warning status
+
+**Verification:**
+- Confirm at least one health check item is displayed
+- Confirm the results are not empty or error states
+
+### TC-05-11: User Preferences Persist
+**Priority:** High
+**Type:** UI
+
+**Steps:**
+1. Navigate to the League Manager page
+2. Select a preferred league from the dropdown (e.g., "Test League")
+3. Select a preferred season (e.g., "2026")
+4. Save or let the preference auto-save
+5. Navigate away to another admin page
+6. Return to the League Manager page
+
+**Expected Result:**
+- The previously selected league and season are pre-selected on return
+- User preferences persist across page navigations
+
+**Verification:**
+- Confirm the dropdowns show the previously selected values
+- Verify via WP-CLI: `wp user meta get 1 spat_preferred_league` (or equivalent) returns the expected value
+
+### TC-05-12: Settings Tab Configuration
+**Priority:** Critical
+**Type:** UI
+
+**Steps:**
+1. Navigate to the League Manager settings tab (or SPAT settings > League Manager)
+2. Set "Default Season" to "2026"
+3. Configure "Fee Source" to an available option
+4. Enable "Debug Logging"
+5. Set "Max Upload Size" to a specific value (e.g., 2MB)
+6. Save settings
+
+**Expected Result:**
+- All settings fields are present and editable
+- Settings save without error
+- A success notice appears
+
+**Verification:**
+- Reload the page and confirm all values persisted
+- Verify via WP-CLI: `wp option get spat_league_manager_settings` (or equivalent) reflects saved values
+
+### TC-05-13: Custom Capability manage_league
+**Priority:** High
+**Type:** Hybrid
+
+**Steps:**
+1. Run WP-CLI: `wp cap list administrator` or `wp role list --fields=role,name`
+2. Check if the `manage_league` capability is assigned to the administrator role
+
+**Expected Result:**
+- The `manage_league` capability exists and is assigned to the administrator role
+
+**Verification:**
+- WP-CLI output confirms `manage_league` is in the administrator's capability list
+- Alternatively: `wp eval "var_dump(current_user_can('manage_league'));"` returns `bool(true)`
+
+### TC-05-14: Contextual Help Tabs
+**Priority:** Medium
+**Type:** UI
+
+**Steps:**
+1. Navigate to the League Manager main page
+2. Click the "Help" tab in the top-right corner of the WordPress admin screen
+3. Review the contextual help content
+4. Repeat for each League Manager subpage (Teams & Rosters, Fee Status, Settings)
+
+**Expected Result:**
+- A contextual help tab is available on each League Manager page
+- The help content is relevant to the current page
+
+**Verification:**
+- Confirm the help tab dropdown opens and contains text
+- Confirm the help content differs per subpage (is contextual, not generic)

--- a/tests/suites/06-player-registration.md
+++ b/tests/suites/06-player-registration.md
@@ -1,0 +1,192 @@
+# Test Suite: Player Registration
+
+## Prerequisites
+- WordPress running at http://sportspress-test with auto-login enabled
+- SportsPress core plugin activated
+- SPAT Player Registration child plugin activated
+- WooCommerce plugin installed and activated (required for full order flow tests)
+- WP-CLI available via `docker exec` or direct shell
+- At least one team and season exist:
+  - `wp term create sp_season "2026"`
+  - `wp post create --post_type=sp_team --post_title="Registration Team" --post_status=publish`
+
+## Test Cases
+
+### TC-06-01: Player Registration Tab on SPAT Settings
+**Priority:** Critical
+**Type:** UI
+
+**Steps:**
+1. Navigate to http://sportspress-test/wp-admin/admin.php?page=spat-settings
+2. Look for a "Player Registration" tab on the settings page
+3. Click the Player Registration tab
+
+**Expected Result:**
+- The SPAT settings page loads without errors
+- A "Player Registration" tab is visible and clickable
+- Clicking the tab reveals Player Registration settings fields
+
+**Verification:**
+- Confirm the tab element exists in the DOM
+- Confirm no PHP errors or warnings appear on the page
+
+### TC-06-02: Settings Save — Auto-Create Player
+**Priority:** Critical
+**Type:** UI
+
+**Steps:**
+1. Navigate to SPAT settings > Player Registration tab
+2. Locate the "Auto-Create Player" toggle/checkbox
+3. Enable the toggle
+4. Save settings
+
+**Expected Result:**
+- The auto-create setting saves without error
+- A success notice appears
+
+**Verification:**
+- Reload the page and confirm the toggle remains enabled
+- Verify via WP-CLI: `wp option get spat_registration_settings` includes auto-create as enabled
+
+### TC-06-03: Settings Save — Auto-Update Player
+**Priority:** High
+**Type:** UI
+
+**Steps:**
+1. On the Player Registration settings tab, locate "Auto-Update Player" toggle
+2. Enable the toggle
+3. Save settings
+
+**Expected Result:**
+- The auto-update setting saves without error
+
+**Verification:**
+- Reload and confirm the toggle state persisted
+
+### TC-06-04: Settings Save — Auto-Role and Player Role
+**Priority:** High
+**Type:** UI
+
+**Steps:**
+1. On the Player Registration settings tab, locate "Auto-Role" toggle and "Player Role" dropdown
+2. Enable Auto-Role
+3. Select a role from the Player Role dropdown (e.g., "Subscriber" or a custom player role)
+4. Save settings
+
+**Expected Result:**
+- Both settings save without error
+- The selected role is stored correctly
+
+**Verification:**
+- Reload and confirm Auto-Role is enabled and the correct role is selected
+- Verify via WP-CLI: `wp option get spat_registration_settings` reflects both values
+
+### TC-06-05: Settings Save — Auto-Season
+**Priority:** High
+**Type:** UI
+
+**Steps:**
+1. On the Player Registration settings tab, locate "Auto-Season" setting
+2. Select "2026" or the current season
+3. Save settings
+
+**Expected Result:**
+- The auto-season setting saves without error
+
+**Verification:**
+- Reload and confirm the season selection persisted
+- Verify via WP-CLI: the option value includes the correct season
+
+### TC-06-06: Settings Persist After Reload
+**Priority:** Critical
+**Type:** UI
+
+**Steps:**
+1. Configure all Player Registration settings (auto-create, auto-update, auto-role, player role, auto-season) to specific values
+2. Save settings
+3. Navigate away to a different admin page (e.g., Dashboard)
+4. Navigate back to SPAT settings > Player Registration tab
+
+**Expected Result:**
+- All previously saved settings retain their values
+- No settings have reverted to defaults
+
+**Verification:**
+- Compare each setting value against what was saved — all must match
+
+### TC-06-07: Database Table spat_registration_logs Exists
+**Priority:** Critical
+**Type:** Hybrid
+
+**Steps:**
+1. Run WP-CLI: `wp db query "SHOW TABLES LIKE '%spat_registration_logs%'"`
+2. Verify the table exists in the output
+
+**Expected Result:**
+- The query returns a row containing the `spat_registration_logs` table name (with the WordPress table prefix)
+
+**Verification:**
+- The output is not empty and contains `spat_registration_logs`
+- Optionally describe the table: `wp db query "DESCRIBE $(wp db prefix)spat_registration_logs"`
+
+### TC-06-08: WP-CLI — Simulate Order Completion and Player Creation
+**Priority:** Critical
+**Type:** Hybrid
+
+**Steps:**
+1. NOTE: This test requires WooCommerce to be active. Skip if WooCommerce is not installed.
+2. Create a WooCommerce order via WP-CLI:
+   `wp wc order create --customer_id=1 --status=pending --user=1`
+3. Add order meta with player details:
+   `wp post meta update {ORDER_ID} _billing_first_name "Auto"`
+   `wp post meta update {ORDER_ID} _billing_last_name "Player"`
+   `wp post meta update {ORDER_ID} _billing_email "autoplayer@example.com"`
+4. Simulate order completion:
+   `wp eval "do_action('woocommerce_order_status_completed', {ORDER_ID});"`
+5. Check if a player was auto-created
+
+**Expected Result:**
+- The order completion hook triggers the player registration logic
+- A new sp_player post is created with the name "Auto Player"
+
+**Verification:**
+- Verify via WP-CLI: `wp post list --post_type=sp_player --fields=ID,post_title` includes "Auto Player"
+- Check the registration log: `wp db query "SELECT * FROM $(wp db prefix)spat_registration_logs ORDER BY id DESC LIMIT 1"`
+
+### TC-06-09: Duplicate Detection Logic
+**Priority:** High
+**Type:** Hybrid
+
+**Steps:**
+1. NOTE: This test requires WooCommerce to be active. Skip if WooCommerce is not installed.
+2. Ensure a player "Auto Player" already exists from TC-06-08
+3. Create another WooCommerce order with the same player details:
+   `wp wc order create --customer_id=1 --status=pending --user=1`
+4. Set the same billing name and email on the new order
+5. Simulate order completion:
+   `wp eval "do_action('woocommerce_order_status_completed', {ORDER_ID});"`
+6. Count sp_player posts with title "Auto Player"
+
+**Expected Result:**
+- The duplicate detection logic prevents creating a second player with the same name/email
+- Only one "Auto Player" sp_player post exists (or the existing one is updated)
+
+**Verification:**
+- Verify via WP-CLI: `wp post list --post_type=sp_player --s="Auto Player" --fields=ID,post_title` returns exactly one result
+- Check the registration log for a duplicate detection entry
+
+### TC-06-10: Activity Logging in registration_logs Table
+**Priority:** High
+**Type:** Hybrid
+
+**Steps:**
+1. After running TC-06-08 and TC-06-09, query the registration logs table
+2. Run: `wp db query "SELECT * FROM $(wp db prefix)spat_registration_logs ORDER BY id DESC LIMIT 5"`
+
+**Expected Result:**
+- The table contains log entries for the player creation and duplicate detection events
+- Each log entry includes relevant details (order ID, player ID, action type, timestamp)
+
+**Verification:**
+- Confirm at least two log entries exist (one creation, one duplicate check)
+- Confirm each entry has non-null values for key columns

--- a/tests/suites/07-etransfer-automation.md
+++ b/tests/suites/07-etransfer-automation.md
@@ -1,0 +1,278 @@
+# Test Suite: e-Transfer Automation
+
+## Prerequisites
+- WordPress running at http://sportspress-test with auto-login enabled
+- SportsPress core plugin activated
+- SPAT e-Transfer Automation child plugin activated
+- WooCommerce plugin installed and activated
+- WP-CLI available via `docker exec` or direct shell
+- At least one WooCommerce order exists for matching tests
+
+## Test Cases
+
+### TC-07-01: e-Transfer Tab on SPAT Settings
+**Priority:** Critical
+**Type:** UI
+
+**Steps:**
+1. Navigate to http://sportspress-test/wp-admin/admin.php?page=spat-settings
+2. Look for an "e-Transfer" tab on the settings page
+3. Click the e-Transfer tab
+
+**Expected Result:**
+- The SPAT settings page loads without errors
+- An "e-Transfer" tab is visible and clickable
+- Clicking the tab reveals e-Transfer Automation settings fields
+
+**Verification:**
+- Confirm the tab element exists in the DOM
+- Confirm no PHP errors or warnings appear on the page
+
+### TC-07-02: Webhook Secret Configuration Saves
+**Priority:** Critical
+**Type:** UI
+
+**Steps:**
+1. Navigate to SPAT settings > e-Transfer tab
+2. Locate the "Webhook Secret" field
+3. Enter a test secret value: `test_webhook_secret_abc123`
+4. Save settings
+
+**Expected Result:**
+- The webhook secret saves without error
+- A success notice appears
+
+**Verification:**
+- Reload the page and confirm the secret field retains the value (may be masked)
+- Verify via WP-CLI: `wp option get spat_etransfer_settings` includes the webhook secret
+
+### TC-07-03: Service Provider Selection Saves
+**Priority:** Critical
+**Type:** UI
+
+**Steps:**
+1. Navigate to SPAT settings > e-Transfer tab
+2. Locate the "Service Provider" dropdown or radio buttons
+3. Select "Generic" and save settings
+4. Reload and confirm "Generic" is selected
+5. Change to "Deliverhook" and save settings
+6. Reload and confirm "Deliverhook" is selected
+7. Change to "Cloudflare" and save settings
+8. Reload and confirm "Cloudflare" is selected
+
+**Expected Result:**
+- Each provider option (generic, deliverhook, cloudflare) saves and persists correctly
+- No errors on save for any option
+
+**Verification:**
+- After each save/reload cycle, confirm the selected provider matches what was chosen
+- Verify via WP-CLI: `wp option get spat_etransfer_settings` reflects the current provider
+
+### TC-07-04: Equivalent Names Configuration
+**Priority:** High
+**Type:** UI
+
+**Steps:**
+1. Navigate to SPAT settings > e-Transfer tab
+2. Locate the "Equivalent Names" configuration section
+3. Add an equivalent name mapping (e.g., "Bob" = "Robert")
+4. Save settings
+5. Reload the page
+
+**Expected Result:**
+- The equivalent names field accepts and saves the mapping
+- After reload, the saved mappings display correctly
+
+**Verification:**
+- Confirm the equivalent names section shows "Bob" = "Robert" after reload
+- Verify via WP-CLI: `wp option get spat_etransfer_settings` includes the equivalent names data
+
+### TC-07-05: WooCommerce e-Transfer Webhooks Page Loads
+**Priority:** Critical
+**Type:** UI
+
+**Steps:**
+1. Navigate to http://sportspress-test/wp-admin/admin.php?page=spet-webhooks (or locate via WooCommerce menu)
+2. If the exact URL differs, look for "e-Transfer Webhooks" under the WooCommerce menu
+
+**Expected Result:**
+- The e-Transfer Webhooks page loads without errors
+- The page displays a list/table of webhook entries (may be empty initially)
+
+**Verification:**
+- Confirm the page renders with a proper heading
+- Confirm a table or list structure is present on the page
+
+### TC-07-06: Pending Count Badge in WooCommerce Menu
+**Priority:** Medium
+**Type:** UI
+
+**Steps:**
+1. Navigate to http://sportspress-test/wp-admin/
+2. Look at the WooCommerce menu item in the admin sidebar
+3. Check for a pending count badge (bubble) next to the e-Transfer Webhooks submenu
+
+**Expected Result:**
+- If there are pending/unmatched webhooks, a count badge appears
+- The badge number reflects the actual count of pending items
+
+**Verification:**
+- Inspect the menu item for a `.awaiting-mod` or `.update-plugins` count bubble
+- If no pending items exist, the badge may not appear (which is correct)
+
+### TC-07-07: REST API Webhook Endpoint Exists
+**Priority:** Critical
+**Type:** API
+
+**Steps:**
+1. Run via WP-CLI: `wp eval "echo rest_url('spet/v1/etransfer-webhook');"`
+2. Test the endpoint with curl: `curl -s -o /dev/null -w '%{http_code}' http://sportspress-test/wp-json/spet/v1/etransfer-webhook`
+3. Send a GET request to verify the endpoint is registered (may return 405 Method Not Allowed for GET if it only accepts POST)
+
+**Expected Result:**
+- The REST API route `spet/v1/etransfer-webhook` is registered
+- The endpoint responds (not 404) — a 405 or 401 response confirms the route exists
+
+**Verification:**
+- Confirm the HTTP response code is not 404
+- Verify via WP-CLI: `wp eval "echo json_encode(rest_get_server()->get_routes()['spet/v1'] ?? 'not found');"` shows the route
+
+### TC-07-08: Webhook Security — HMAC Signature Verification
+**Priority:** Critical
+**Type:** API
+
+**Steps:**
+1. Ensure a webhook secret is configured (from TC-07-02)
+2. Send a POST request to the webhook endpoint without an HMAC signature:
+   `curl -X POST http://sportspress-test/wp-json/spet/v1/etransfer-webhook -H "Content-Type: application/json" -d '{"test": true}'`
+3. Send a POST request with an invalid HMAC signature:
+   `curl -X POST http://sportspress-test/wp-json/spet/v1/etransfer-webhook -H "Content-Type: application/json" -H "X-Signature: invalid" -d '{"test": true}'`
+4. Compute a valid HMAC-SHA256 signature and send with the correct header
+
+**Expected Result:**
+- Request without signature is rejected (401 or 403)
+- Request with invalid signature is rejected (401 or 403)
+- Request with valid signature is accepted (200 or appropriate success code)
+
+**Verification:**
+- Confirm each response code matches the expected behavior
+- Check error messages in the response body for unsigned/invalid requests
+
+### TC-07-09: Webhook Security — Replay Protection
+**Priority:** High
+**Type:** API
+
+**Steps:**
+1. Send a valid webhook request with a timestamp and valid HMAC signature
+2. Record the request details (body, headers)
+3. Wait a few seconds, then replay the exact same request
+
+**Expected Result:**
+- The replayed request is rejected with an appropriate error (e.g., "duplicate" or "replay detected")
+
+**Verification:**
+- Confirm the replay response code indicates rejection
+- Confirm the error message references replay or duplicate detection
+
+### TC-07-10: Webhook Security — Rate Limiting
+**Priority:** High
+**Type:** API
+
+**Steps:**
+1. Send multiple rapid POST requests to the webhook endpoint (e.g., 20 requests in quick succession):
+   `for i in $(seq 1 20); do curl -s -o /dev/null -w '%{http_code}\n' -X POST http://sportspress-test/wp-json/spet/v1/etransfer-webhook -d '{}'; done`
+2. Observe the response codes
+
+**Expected Result:**
+- After exceeding the rate limit, requests receive a 429 Too Many Requests response
+- Earlier requests within the limit receive normal responses
+
+**Verification:**
+- Confirm at least one 429 response appears in the output
+- Confirm the rate limit resets after the cooldown period
+
+### TC-07-11: Manual Match Interface
+**Priority:** High
+**Type:** UI
+
+**Steps:**
+1. Ensure at least one unmatched webhook entry exists (from TC-07-08 or by inserting a test log entry)
+2. Navigate to the e-Transfer Webhooks page
+3. Locate an unmatched webhook entry
+4. Click "Match" or "Manual Match" on the entry
+5. Select a WooCommerce order to match it to
+6. Confirm the match
+
+**Expected Result:**
+- The manual match interface opens (modal, inline form, or separate page)
+- An order search/selection mechanism is available
+- After matching, the webhook entry status updates to "matched"
+
+**Verification:**
+- Confirm the webhook entry now shows as matched with the order ID
+- Verify via WP-CLI: `wp db query "SELECT * FROM $(wp db prefix)spet_etransfer_logs WHERE status='matched' ORDER BY id DESC LIMIT 1"`
+
+### TC-07-12: Activity Log Displays Webhook History
+**Priority:** High
+**Type:** UI
+
+**Steps:**
+1. Navigate to the e-Transfer Webhooks page
+2. Review the activity log or webhook history section
+
+**Expected Result:**
+- The page displays a chronological log of webhook events
+- Each entry shows timestamp, status, sender info, and amount (if available)
+
+**Verification:**
+- Confirm log entries are visible and ordered by date
+- Confirm entries from previous test cases appear in the log
+
+### TC-07-13: Hide Log Entry Functionality
+**Priority:** Medium
+**Type:** UI
+
+**Steps:**
+1. Navigate to the e-Transfer Webhooks page
+2. Locate a log entry
+3. Click "Hide" or "Dismiss" on the entry
+4. Confirm the action
+
+**Expected Result:**
+- The log entry is hidden from the default view
+- The entry is not permanently deleted (may be viewable with a "show hidden" filter)
+
+**Verification:**
+- Confirm the hidden entry no longer appears in the default list
+- Verify via WP-CLI: `wp db query "SELECT * FROM $(wp db prefix)spet_etransfer_logs WHERE hidden=1 ORDER BY id DESC LIMIT 1"` shows the hidden entry
+
+### TC-07-14: Cron Job spet_cleanup_old_logs Scheduled
+**Priority:** Medium
+**Type:** Hybrid
+
+**Steps:**
+1. Run WP-CLI: `wp cron event list --fields=hook,next_run_relative,recurrence`
+2. Search for `spet_cleanup_old_logs` in the output
+
+**Expected Result:**
+- The cron event `spet_cleanup_old_logs` is listed in the scheduled events
+- It has a recurrence schedule (e.g., daily or weekly)
+
+**Verification:**
+- Confirm the hook name appears in the cron event list
+- Confirm the recurrence is not "Non-repeating" (it should be a recurring schedule)
+
+### TC-07-15: Database Table spet_etransfer_logs Exists
+**Priority:** Critical
+**Type:** Hybrid
+
+**Steps:**
+1. Run WP-CLI: `wp db query "SHOW TABLES LIKE '%spet_etransfer_logs%'"`
+2. Verify the table exists in the output
+
+**Expected Result:**
+- The query returns a row containing the `spet_etransfer_logs` table name (with the WordPress table prefix)
+
+**Verification:**
+- The output is not empty and contains `spet_etransfer_logs`
+- Optionally describe the table: `wp db query "DESCRIBE $(wp db prefix)spet_etransfer_logs"`


### PR DESCRIPTION
Adds complete LLM agent testing infrastructure:

- Playwright MCP server for browser automation
- Agent-readable test suites (8 suites, ~100 test cases)
- Test runner, state reset, and JUnit report converter
- Health endpoint for environment readiness checks
- GitHub Actions CI workflow for agent tests
- Updated compose.yml with Playwright, Mailhog, and Adminer services

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added health check endpoint for WordPress monitoring and diagnostics
  * Integrated Playwright testing support for automated quality assurance

* **Documentation**
  * Updated setup guides with testing and automation workflows
  * Added comprehensive test suite documentation for quality validation

* **Chores**
  * Updated WordPress service port from 8081 to 8082
  * Enhanced Docker Compose with health checks, improved resource allocation, and test infrastructure
  * Added baseline state management and test reporting capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->