### PR TITLE
feat: ENV-configurable WP settings + docs update

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,16 @@
 #          cricket, floorball, football, handball, netball
 SPORTSPRESS_SPORT=ice-hockey
 
+# WordPress site settings
+WORDPRESS_TITLE=SportsPress Test Site
+WORDPRESS_ADMIN_USER=admin
+WORDPRESS_ADMIN_PASSWORD=admin
+WORDPRESS_ADMIN_EMAIL=admin@test.com
+
+# WordPress configuration
+WP_DEBUG=true
+WP_MEMORY_LIMIT=128M
+
 # Database credentials (internal MariaDB)
 WORDPRESS_DB_HOST=localhost:/run/mysqld/mysqld.sock
 WORDPRESS_DB_USER=wordpress

--- a/Dockerfile.playwright
+++ b/Dockerfile.playwright
@@ -1,8 +1,10 @@
 FROM mcr.microsoft.com/playwright:v1.59.1-noble
 
-# Install curl (for healthcheck) and Chrome dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends curl xdg-utils && rm -rf /var/lib/apt/lists/*
-RUN npx playwright install chrome
+# Install curl (for healthcheck) and Google Chrome with all dependencies
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && npx playwright install --with-deps chrome \
+    && rm -rf /var/lib/apt/lists/*
 
 # Install the MCP server package so startup is instant
 RUN npm install -g @playwright/mcp@0.0.70

--- a/Dockerfile.playwright
+++ b/Dockerfile.playwright
@@ -1,7 +1,7 @@
 FROM mcr.microsoft.com/playwright:v1.59.1-noble
 
-# Install curl (for healthcheck) and Google Chrome (required by @playwright/mcp)
-RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
+# Install curl (for healthcheck) and Chrome dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends curl xdg-utils && rm -rf /var/lib/apt/lists/*
 RUN npx playwright install chrome
 
 # Install the MCP server package so startup is instant

--- a/README.md
+++ b/README.md
@@ -100,8 +100,10 @@ Returns:
   "wordpress": "6.9.4",
   "sportspress": "2.7.29",
   "sport": "ice-hockey",
-  "plugins": ["sportspress", "sportspress-admin-tools", ...],
+  "plugins": ["sportspress", "woocommerce", "sportspress-admin-tools", ...],
   "theme": "rookie",
+  "auto_login": true,
+  "baseline_exists": true,
   "timestamp": "2026-04-16T18:30:00+00:00"
 }
 ```
@@ -172,6 +174,7 @@ Set `SPORTSPRESS_SPORT` environment variable:
 ## Features
 
 - **Auto-Login** — Automatically logged in as admin (no credentials needed)
+- **WooCommerce** — WooCommerce pre-installed and activated (onboarding skipped)
 - **Debug Tools** — Query Monitor, Debug Bar, and User Switching pre-installed
 - **Email Capture** — All outgoing email routed via SMTP to Mailpit for inspection
 - **MCP Server** — WordPress MCP Server plugin installed (inactive by default)
@@ -228,6 +231,24 @@ The `agent-tests.yml` workflow runs on push to main and pull requests:
     ├── build-image.yml                 # Docker image build
     └── check-updates.yml               # Dependency update checks
 ```
+
+## Environment Variables
+
+All configuration can be set via environment variables in `compose.yml` or a `.env` file. See `.env.example` for a template.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SPORTSPRESS_SPORT` | `ice-hockey` | Sport preset for demo data (see Sports Available) |
+| `WORDPRESS_TITLE` | `SportsPress Test Site` | Site title |
+| `WORDPRESS_ADMIN_USER` | `admin` | Admin username |
+| `WORDPRESS_ADMIN_PASSWORD` | `admin` | Admin password |
+| `WORDPRESS_ADMIN_EMAIL` | `admin@test.com` | Admin email |
+| `WP_DEBUG` | `true` | Enable WordPress debug mode |
+| `WP_MEMORY_LIMIT` | `128M` | WordPress memory limit |
+| `WORDPRESS_DB_HOST` | `localhost:/run/mysqld/mysqld.sock` | Database host (or external host) |
+| `WORDPRESS_DB_USER` | `wordpress` | Database username |
+| `WORDPRESS_DB_PASSWORD` | `wordpress` | Database password |
+| `WORDPRESS_DB_NAME` | `wordpress` | Database name |
 
 ## External Database
 

--- a/config/scripts/setup-test-data.sh
+++ b/config/scripts/setup-test-data.sh
@@ -38,12 +38,17 @@ if [[ "$DB_HOST" == "localhost"* ]] || [[ "$DB_HOST" == "127.0.0.1"* ]]; then
 fi
 
 # Install WordPress
+WP_TITLE=${WORDPRESS_TITLE:-SportsPress Test Site}
+WP_ADMIN_USER=${WORDPRESS_ADMIN_USER:-admin}
+WP_ADMIN_PASSWORD=${WORDPRESS_ADMIN_PASSWORD:-admin}
+WP_ADMIN_EMAIL=${WORDPRESS_ADMIN_EMAIL:-admin@test.com}
+
 wp core install \
     --url="http://localhost" \
-    --title="SportsPress Test Site" \
-    --admin_user="admin" \
-    --admin_password="admin" \
-    --admin_email="admin@test.com" \
+    --title="$WP_TITLE" \
+    --admin_user="$WP_ADMIN_USER" \
+    --admin_password="$WP_ADMIN_PASSWORD" \
+    --admin_email="$WP_ADMIN_EMAIL" \
     --allow-root
 
 # Configure WordPress options

--- a/config/wordpress/wp-config.php
+++ b/config/wordpress/wp-config.php
@@ -18,12 +18,12 @@ define('LOGGED_IN_SALT',   'test-salt');
 define('NONCE_SALT',       'test-salt');
 
 $table_prefix = 'wp_';
-define('WP_DEBUG', true);
+define('WP_DEBUG', filter_var(getenv('WP_DEBUG') ?: 'true', FILTER_VALIDATE_BOOLEAN));
 define('WP_DEBUG_DISPLAY', false);
 define('SCRIPT_DEBUG', true);
 define('DISABLE_WP_CRON', true);
 define('AUTOMATIC_UPDATER_DISABLED', true);
-define('WP_MEMORY_LIMIT', '128M');
+define('WP_MEMORY_LIMIT', getenv('WP_MEMORY_LIMIT') ?: '128M');
 ini_set('memory_limit', '256M');
 
 // Dynamic URL configuration — only trust expected hosts


### PR DESCRIPTION
Makes hardcoded WordPress config values ENV-configurable. Updates README with WooCommerce, health endpoint fields, and full ENV vars table.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * WordPress installation now supports environment variable configuration for site title, admin credentials, debug mode, and memory settings.
  * WooCommerce is now pre-installed and activated.

* **Documentation**
  * Added "Environment Variables" section to README documenting available configuration options and their defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->