### PR TITLE
fix: sp_season taxonomy guard + health endpoint race condition

### DIFF
--- a/TODO-sportspress-has-seasons.md
+++ b/TODO-sportspress-has-seasons.md
@@ -1,0 +1,88 @@
+# TODO: `sp_season` taxonomy never registers in this environment
+
+Found 2026-08-25 while seeding an E2E fixture for a different project
+(rookiehockey-blueline's homepage standings tab strip). Writing this down
+here since it's this repo's bug, not that one's.
+
+## The bug
+
+SportsPress core (`ThemeBoy/SportsPress`, `includes/class-sp-post-types.php`,
+`SP_Post_types::register_taxonomies()`) only registers the `sp_season`
+taxonomy when this resolves truthy:
+
+```php
+if ( apply_filters( 'sportspress_has_seasons', true ) ) :
+    ...
+    register_taxonomy( 'sp_season', $object_types, $args );
+endif;
+```
+
+In this sandbox image, that filter resolves **false** — confirmed live,
+twice, in a real running container:
+
+```
+$ wp term create sp_season "Test" --allow-root
+Error: Invalid taxonomy.
+
+$ wp eval-file some-script-calling-wp_insert_term.php --allow-root
+Failed to create sp_season term: Invalid taxonomy.
+```
+
+I didn't track down *what* filters it to false (some other plugin, a
+setting, or SportsPress's own conditional logic based on the active sport
+preset) — that's the actual thing to find. Whatever it is, it means
+`sp_season` is unusable out of the box here, even though it's a real,
+core-registered taxonomy that production sites (rookiehockey.ca) use
+constantly.
+
+## It's already silently breaking `generate-extra-data.php`
+
+`config/scripts/generate-extra-data.php`'s own `create_sp_term()` helper
+(line 16) *does* check `is_wp_error()` on `wp_insert_term()` and echoes an
+error + returns `false` — so every image build has almost certainly been
+printing something like:
+
+```
+❌ Error creating term 2024: Invalid taxonomy.
+❌ Error creating term 2025: Invalid taxonomy.
+```
+
+...into the build log (worth grepping a real build log to confirm), with
+`$season_ids` ending up empty. Everything downstream that assumes real
+season ids exist is suspect:
+
+- `$season_id = array_values($season_ids)[0];` (line 140) — undefined
+  array key, `$season_id` ends up `null`.
+- Every `wp_set_object_terms( ..., 'sp_season' )` call for teams/players/
+  staff/events/tables/lists/calendars (lines 74, 107, 133, 166, 204, 220,
+  236) either sets nothing or sets `[null]`.
+
+None of this fails the build (the script has no `set -e`-style bailout on
+these particular errors), so it's been quietly not doing what it claims to
+for however long this has been the case. Worth actually checking a build
+log rather than assuming — I haven't done that, just traced the code path.
+
+## Suggested fix (pick one)
+
+1. **Find and fix the actual filter source.** Grep the built image's active
+   plugins for `sportspress_has_seasons` (or whatever adds a filter on it)
+   and see why it's forcing `false`. This is the "real" fix if some other
+   plugin or setting is doing this on purpose for a reason that no longer
+   applies.
+2. **Cheaper workaround**: add `add_filter( 'sportspress_has_seasons', '__return_true' );`
+   somewhere early in `config/scripts/setup-test-data.sh` (or a small
+   mu-plugin), before `generate-extra-data.php` runs. Doesn't explain the
+   root cause, but unblocks season data reliably regardless of what's
+   filtering it.
+3. Once fixed, re-check `create_sp_term()`'s own error path actually stops
+   firing for `sp_season`, and that `$season_id` downstream is a real int,
+   not null.
+
+## How I worked around it on the consuming side (for reference)
+
+In the other project's E2E fixture, rather than depend on this repo's
+behavior, I had the fixture script register `sp_season` itself if
+`taxonomy_exists('sp_season')` is false, using the same object types core
+registers it against. That's a fine permanent workaround for *that*
+project either way, but it means this repo's own bug can keep hiding here
+unless something else surfaces it.

--- a/compose.yml
+++ b/compose.yml
@@ -40,7 +40,7 @@ services:
     networks:
       - sp-test-net
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://localhost/wp-json/test/v1/health"]
+      test: ["CMD-SHELL", "curl -sf http://localhost/wp-json/test/v1/health | grep -q '\"status\":\"ready\"'"]
       interval: 10s
       timeout: 5s
       retries: 30

--- a/config/scripts/generate-extra-data.php
+++ b/config/scripts/generate-extra-data.php
@@ -35,11 +35,20 @@ foreach ( $leagues as $league ) {
 }
 
 // 2. Create Seasons
-$seasons = [ '2024', '2025' ];
-$season_ids = [];
-foreach ( $seasons as $season ) {
-	$id = create_sp_term( $season, 'sp_season' );
-	if ( $id ) $season_ids[$season] = $id;
+// Guard: if sp_season isn't registered (e.g. filter race), bail early with a clear message.
+if ( ! taxonomy_exists( 'sp_season' ) ) {
+	echo "❌ sp_season taxonomy is not registered. Ensure sportspress_has_seasons filter returns true.\n";
+	echo "   Skipping all season-related data creation.\n";
+	// Use current year as a no-op fallback so downstream $season_id checks don't fatal.
+	$season_ids = [];
+} else {
+	$current_year = (int) date( 'Y' );
+	$seasons = [ (string)($current_year - 1), (string)$current_year ];
+	$season_ids = [];
+	foreach ( $seasons as $season ) {
+		$id = create_sp_term( $season, 'sp_season' );
+		if ( $id ) $season_ids[$season] = $id;
+	}
 }
 
 // 3. Create Positions
@@ -137,8 +146,12 @@ foreach ( $staff_names as $staff_name ) {
 
 // 7. Create Events (Matches)
 // Create a few matches for the first season and first league
-$season_id = array_values($season_ids)[0];
-$league_id = array_values($league_ids)[0];
+$season_id = ! empty( $season_ids ) ? array_values($season_ids)[0] : null;
+$league_id = ! empty( $league_ids ) ? array_values($league_ids)[0] : null;
+
+if ( ! $season_id || ! $league_id ) {
+	echo "⚠️  Skipping event creation: missing season or league IDs.\n";
+} else {
 
 for ( $i = 0; $i < 6; $i++ ) {
 	// Random home and away teams
@@ -186,10 +199,12 @@ for ( $i = 0; $i < 6; $i++ ) {
 			'post_date_gmt' => $date,
 		] );
 	}
-}
+} // end for loop
+} // end if season_id && league_id
 
 // 8. Create League Table
-$table_title = 'League Table ' . $seasons[0];
+$season_label = ! empty( $season_ids ) ? array_key_first( $season_ids ) : date('Y');
+$table_title = 'League Table ' . $season_label;
 $table_id = post_exists( $table_title, '', '', 'sp_table' );
 if ( ! $table_id ) {
 	$table_id = wp_insert_post( [
@@ -200,12 +215,12 @@ if ( ! $table_id ) {
 	echo "✅ Created Table: $table_title ($table_id)\n";
 }
 if ( $table_id ) {
-	wp_set_object_terms( $table_id, [ $league_id ], 'sp_league' );
-	wp_set_object_terms( $table_id, [ $season_id ], 'sp_season' );
+	if ( $league_id ) wp_set_object_terms( $table_id, [ $league_id ], 'sp_league' );
+	if ( $season_id ) wp_set_object_terms( $table_id, [ $season_id ], 'sp_season' );
 }
 
 // 9. Create Player List
-$list_title = 'Player List ' . $seasons[0];
+$list_title = 'Player List ' . $season_label;
 $list_id = post_exists( $list_title, '', '', 'sp_list' );
 if ( ! $list_id ) {
 	$list_id = wp_insert_post( [
@@ -216,12 +231,12 @@ if ( ! $list_id ) {
 	echo "✅ Created Player List: $list_title ($list_id)\n";
 }
 if ( $list_id ) {
-	wp_set_object_terms( $list_id, [ $league_id ], 'sp_league' );
-	wp_set_object_terms( $list_id, [ $season_id ], 'sp_season' );
+	if ( $league_id ) wp_set_object_terms( $list_id, [ $league_id ], 'sp_league' );
+	if ( $season_id ) wp_set_object_terms( $list_id, [ $season_id ], 'sp_season' );
 }
 
 // 10. Create Calendar
-$calendar_title = 'Calendar ' . $seasons[0];
+$calendar_title = 'Calendar ' . $season_label;
 $calendar_id = post_exists( $calendar_title, '', '', 'sp_calendar' );
 if ( ! $calendar_id ) {
 	$calendar_id = wp_insert_post( [
@@ -232,8 +247,8 @@ if ( ! $calendar_id ) {
 	echo "✅ Created Calendar: $calendar_title ($calendar_id)\n";
 }
 if ( $calendar_id ) {
-	wp_set_object_terms( $calendar_id, [ $league_id ], 'sp_league' );
-	wp_set_object_terms( $calendar_id, [ $season_id ], 'sp_season' );
+	if ( $league_id ) wp_set_object_terms( $calendar_id, [ $league_id ], 'sp_league' );
+	if ( $season_id ) wp_set_object_terms( $calendar_id, [ $season_id ], 'sp_season' );
 }
 
 // 11. Create Metrics

--- a/config/wordpress/mu-plugins/rest-api-health.php
+++ b/config/wordpress/mu-plugins/rest-api-health.php
@@ -30,15 +30,17 @@ function sp_test_health_callback() {
         return dirname($p);
     }, $active_plugins);
 
+    $baseline_exists = file_exists('/var/lib/baseline/baseline.sql');
+
     return new WP_REST_Response([
-        'status'          => 'ready',
+        'status'          => $baseline_exists ? 'ready' : 'setting-up',
         'wordpress'       => get_bloginfo('version'),
         'sportspress'     => defined('SP_VERSION') ? SP_VERSION : 'not-active',
         'sport'           => get_option('sportspress_sport', 'unknown'),
         'plugins'         => array_values($plugin_slugs),
         'theme'           => get_stylesheet(),
         'auto_login'      => file_exists(WPMU_PLUGIN_DIR . '/auto-login.php'),
-        'baseline_exists' => file_exists('/var/lib/baseline/baseline.sql'),
+        'baseline_exists' => $baseline_exists,
         'timestamp'       => gmdate('c'),
     ], 200);
 }

--- a/config/wordpress/mu-plugins/sportspress-season-fix.php
+++ b/config/wordpress/mu-plugins/sportspress-season-fix.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Plugin Name: SportsPress Season Fix
+ * Description: Ensures the sp_season taxonomy is always registered in the test
+ *              environment. SportsPress gates registration behind the
+ *              sportspress_has_seasons filter (default true), but this guard
+ *              makes it unconditional so no plugin or timing issue can suppress it.
+ */
+
+// Force the filter true early — before SportsPress's init hook (priority 10)
+// registers taxonomies so it's resolved correctly on every WP-CLI invocation.
+add_filter('sportspress_has_seasons', '__return_true', 1);


### PR DESCRIPTION
Addresses two issues from TODO-sportspress-has-seasons.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved setup health reporting to distinguish between ready and still-initializing environments.
  * Updated sample data generation to use the current and previous seasons.
  * Prevented setup failures when season or league data is unavailable.
  * Ensured SportsPress seasons are available during initialization.

* **Documentation**
  * Added troubleshooting guidance for missing SportsPress season taxonomies and related setup errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->